### PR TITLE
Improve tracers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+phpstan.neon.dist export-ignore

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -30,7 +30,7 @@ jobs:
           wget https://raw.githubusercontent.com/JetBrains/phpstorm-stubs/master/newrelic/newrelic.php
 
       - name: Run PHPStan
-        run: composer run stan
+        run: composer run phpstan
 
   editorconfig:
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,6 @@
 name: Code style
 
-on: [push, pull_request]
+on: push
 
 jobs:
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "scripts": {
         "bench": "phpbench run --report=redis",
         "bench:verbose": "phpbench run --report=redis --progress=blinken",
-        "stan": "phpstan analyse"
+        "phpstan": "phpstan analyse"
     },
     "require": {
         "php": "^7.4|^8.0",

--- a/src/Credis/RelayCredisAdapter.php
+++ b/src/Credis/RelayCredisAdapter.php
@@ -52,7 +52,7 @@ class RelayCredisAdapter
      */
     public function connect(): void
     {
-        throw new LogicException('Connection must be established in Relay.');
+        throw new LogicException('Connection must be established in Relay');
     }
 
     /**

--- a/src/Laravel/RelayConnector.php
+++ b/src/Laravel/RelayConnector.php
@@ -49,7 +49,7 @@ class RelayConnector extends PhpRedisConnector implements Connector
      */
     public function connectToCluster(array $config, array $clusterOptions, array $options)
     {
-        throw new LogicException('Relay does not support clusters, at this point.');
+        throw new LogicException('Relay does not support clusters, at this point');
     }
 
     /**

--- a/src/Psr/SimpleCache/RelayCache.php
+++ b/src/Psr/SimpleCache/RelayCache.php
@@ -107,7 +107,7 @@ class RelayCache implements CacheInterface
 
         if (! \is_array($keys)) {
             throw new InvalidArgumentException(
-                \sprintf('Cache keys must be array or Traversable, "%s" given.', \gettype($keys))
+                \sprintf('Cache keys must be array or Traversable, "%s" given', \gettype($keys))
             );
         }
 
@@ -135,7 +135,7 @@ class RelayCache implements CacheInterface
 
         if (! \is_array($values)) {
             throw new InvalidArgumentException(
-                \sprintf('Cache keys must be array or Traversable, "%s" given.', \gettype($values))
+                \sprintf('Cache keys must be array or Traversable, "%s" given', \gettype($values))
             );
         }
 
@@ -171,7 +171,7 @@ class RelayCache implements CacheInterface
 
         if (! \is_array($keys)) {
             throw new InvalidArgumentException(
-                \sprintf('Cache keys must be array or Traversable, "%s" given.', \gettype($keys))
+                \sprintf('Cache keys must be array or Traversable, "%s" given', \gettype($keys))
             );
         }
 

--- a/src/Psr/Tracing/RelayNewRelic.php
+++ b/src/Psr/Tracing/RelayNewRelic.php
@@ -240,7 +240,7 @@ class RelayNewRelic
             return $pipe->exec();
         }, [
             'product' => 'Redis',
-            'operation' => $method,
+            'operation' => 'exec',
         ]);
     }
 }

--- a/src/Psr/Tracing/RelayNewRelic.php
+++ b/src/Psr/Tracing/RelayNewRelic.php
@@ -17,7 +17,39 @@ class RelayNewRelic
      *
      * @var \Relay\Relay
      */
-    protected $relay;
+    protected Relay $relay;
+
+    /**
+     * Untraced client methods.
+     *
+     * @var array<int, string>
+     */
+    public const Untraced = [
+        'listen',
+        'onFlushed',
+        'onInvalidated',
+        'dispatchEvents',
+        'endpointId',
+        'socketId',
+        'idleTime',
+        'option',
+        'getOption',
+        'setOption',
+        'readTimeout',
+        'getReadTimeout',
+        'getHost',
+        'getPort',
+        'getAuth',
+        'getDbNum',
+        'getMode',
+        'getLastError',
+        'clearLastError',
+        '_serialize',
+        '_unserialize',
+        '_pack',
+        '_unpack',
+        '_prefix',
+    ];
 
     /**
      * Creates a new instance.
@@ -31,10 +63,16 @@ class RelayNewRelic
             throw new LogicException('Function `newrelic_record_datastore_segment()` was not found');
         }
 
-        $this->relay = newrelic_record_datastore_segment( // @phpstan-ignore-line
+        $relay = newrelic_record_datastore_segment(
             $client,
-            [ 'product' => 'Redis', 'operation' => '__construct']
+            ['product' => 'Redis', 'operation' => '__construct']
         );
+
+        if (! $relay instanceof Relay) {
+            throw new LogicException('Client is not a Relay instance');
+        }
+
+        $this->relay = $relay;
     }
 
     /**
@@ -46,6 +84,10 @@ class RelayNewRelic
      */
     public function __call(string $name, array $arguments)
     {
+        if (in_array($name, self::Untraced)) {
+            return $this->relay->{$name}(...$arguments);
+        }
+
         return newrelic_record_datastore_segment(
             fn () => $this->relay->{$name}(...$arguments),
             ['product' => 'Redis', 'operation' => $name]
@@ -82,7 +124,7 @@ class RelayNewRelic
             return $this->relay->scan($iterator, $match, $count, $type);
         }, [
             'product' => 'Redis',
-            'operation' => 'scan'
+            'operation' => 'scan',
         ]);
     }
 
@@ -101,7 +143,7 @@ class RelayNewRelic
             return $this->relay->hscan($key, $iterator, $match, $count);
         }, [
             'product' => 'Redis',
-            'operation' => 'hscan'
+            'operation' => 'hscan',
         ]);
     }
 
@@ -120,7 +162,7 @@ class RelayNewRelic
             return $this->relay->sscan($key, $iterator, $match, $count);
         }, [
             'product' => 'Redis',
-            'operation' => 'sscan'
+            'operation' => 'sscan',
         ]);
     }
 
@@ -139,7 +181,64 @@ class RelayNewRelic
             return $this->relay->zscan($key, $iterator, $match, $count);
         }, [
             'product' => 'Redis',
-            'operation' => 'zscan'
+            'operation' => 'zscan',
+        ]);
+    }
+
+    /**
+     * Hijack pipelines.
+     *
+     * @return \CacheWerk\Relay\Psr\Tracing\Transaction
+     */
+    public function pipeline()
+    {
+        return new Transaction($this, Relay::PIPELINE);
+    }
+
+    /**
+     * Hijack pipelines.
+     *
+     * @param  int  $mode
+     * @return \CacheWerk\Relay\Psr\Tracing\Transaction
+     */
+    public function multi(int $mode = Relay::MULTI)
+    {
+        return new Transaction($this, $mode);
+    }
+
+    /**
+     * Block non-chained transactions.
+     *
+     * @return void
+     */
+    public function exec()
+    {
+        throw new LogicException('Non-chained transactions are not supported.');
+    }
+
+    /**
+     * Executes buffered transaction inside New Relic's datastore segment function.
+     *
+     * @param  \CacheWerk\Relay\Psr\Tracing\Transaction  $transaction
+     * @return array<int, mixed>|bool
+     */
+    public function executeBufferedTransaction(Transaction $transaction)
+    {
+        $method = $transaction->type === Relay::PIPELINE
+            ? 'pipeline'
+            : 'multi';
+
+        return newrelic_record_datastore_segment(function () use ($method, $transaction) {
+            $pipe = $this->relay->{$method}();
+
+            foreach ($transaction->commands as $command) {
+                $pipe->{$command[0]}(...$command[1]);
+            }
+
+            return $pipe->exec();
+        }, [
+            'product' => 'Redis',
+            'operation' => $method,
         ]);
     }
 }

--- a/src/Psr/Tracing/RelayNewRelic.php
+++ b/src/Psr/Tracing/RelayNewRelic.php
@@ -213,11 +213,13 @@ class RelayNewRelic
      */
     public function exec()
     {
-        throw new LogicException('Non-chained transactions are not supported.');
+        throw new LogicException('Non-chained transactions are not supported');
     }
 
     /**
      * Executes buffered transaction inside New Relic's datastore segment function.
+     *
+     * @phpstan-return mixed
      *
      * @param  \CacheWerk\Relay\Psr\Tracing\Transaction  $transaction
      * @return array<int, mixed>|bool

--- a/src/Psr/Tracing/RelayOpenTelemetry.php
+++ b/src/Psr/Tracing/RelayOpenTelemetry.php
@@ -21,7 +21,7 @@ class RelayOpenTelemetry
      *
      * @var \Relay\Relay
      */
-    protected $relay;
+    protected Relay $relay;
 
     /**
      * The OpenTelemetry tracer provider instance.

--- a/src/Psr/Tracing/Transaction.php
+++ b/src/Psr/Tracing/Transaction.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CacheWerk\Relay\Psr\Tracing;
+
+use LogicException;
+
+use Relay\Relay;
+
+class Transaction
+{
+    /**
+     * The transaction type.
+     *
+     * @var int
+     */
+    public int $type;
+
+    /**
+     * The buffered commands.
+     *
+     * @var array<int, array{string, mixed}>
+     */
+    public array $commands = [];
+
+    /**
+     * The underlying Relay client.
+     *
+     * @var object
+     */
+    private object $client;
+
+    /**
+     * Creates a new buffered transaction.
+     *
+     * @param  object  $client
+     * @param  int  $type
+     * @return void
+     */
+    public function __construct($client, int $type)
+    {
+        $this->type = $type;
+        $this->client = $client;
+    }
+
+    /**
+     * Buffers called commands.
+     *
+     * @param  string  $method
+     * @param  array<mixed>  $arguments
+     * @return $this
+     */
+    public function __call($method, $arguments)
+    {
+        $this->commands[] = [$method, $arguments];
+
+        return $this;
+    }
+
+    /**
+     * Executes the transaction on the client.
+     *
+     * @return array<mixed>|bool
+     */
+    public function exec()
+    {
+        return $this->client->executeBufferedTransaction($this);
+    }
+
+    /**
+     * Blocks nested transactions.
+     *
+     * @return void
+     */
+    public function pipeline()
+    {
+        throw new LogicException('Nested transactions are not supported.');
+    }
+
+    /**
+     * Blocks nested transactions.
+     *
+     * @param  int  $mode
+     * @return void
+     */
+    public function multi(int $mode = Relay::MULTI)
+    {
+        throw new LogicException('Nested transactions are not supported.');
+    }
+}

--- a/src/Psr/Tracing/Transaction.php
+++ b/src/Psr/Tracing/Transaction.php
@@ -65,6 +65,10 @@ class Transaction
      */
     public function exec()
     {
+        if (! method_exists($this->client, 'executeBufferedTransaction')) {
+            throw new LogicException('Client cannot execute buffered transactions');
+        }
+
         return $this->client->executeBufferedTransaction($this);
     }
 
@@ -75,7 +79,7 @@ class Transaction
      */
     public function pipeline()
     {
-        throw new LogicException('Nested transactions are not supported.');
+        throw new LogicException('Nested transactions are not supported');
     }
 
     /**
@@ -86,6 +90,6 @@ class Transaction
      */
     public function multi(int $mode = Relay::MULTI)
     {
-        throw new LogicException('Nested transactions are not supported.');
+        throw new LogicException('Nested transactions are not supported');
     }
 }


### PR DESCRIPTION
- Support `multi()` and `pipeline()` transactions
- Don't trace local methods that don't communicate with Redis
- Ensure callable returns `Relay` instance