### PR TITLE
Make PHPStan ignores robust and simple

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,10 @@
 name: Code style
 
-on: push
+on:
+  pull_request: null
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -11,8 +11,8 @@ parameters:
     - src/
 
   ignoreErrors:
-    - '#Parameter .+? expects Redis, Relay\\Relay given#'
-    - '#Return type \(Relay\\Relay\) of method .+? should be compatible with return type \(Redis\) of method#'
-    - '#PHPDoc type Relay\\Relay of property .+? is not covariant with PHPDoc type Redis#'
-    - '#Method .+?\\RelayNewRelic::[\w]?scan\(\) should return .+? but returns mixed#'
-    - '#Call to an undefined method Redis::_(un)?pack\(\)#'
+    - '#^Parameter \S+ expects Redis, Relay\\Relay given#'
+    - '#^Return type \(Relay\\Relay\) of method \S+ should be compatible with return type \(Redis\) of method#'
+    - '#^PHPDoc type Relay\\Relay of property \S+ is not covariant with PHPDoc type Redis#'
+    - '#^Method \S+\\RelayNewRelic::scan\(\) should return \S+ but returns mixed#'
+    - '#^Call to an undefined method Redis::(_pack|_unpack)\(\)#'

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -11,7 +11,8 @@ parameters:
     - src/
 
   ignoreErrors:
-    - '#^Parameter \S+ expects Redis, Relay\\Relay given#'
+    - '#^Parameter \#1 \$client of class CacheWerk\\Relay\\Laravel\\RelayConnection constructor expects Redis, Relay\\Relay given\.$#'
+    - '#^Parameter \#1 \$client of method Illuminate\\Redis\\Connectors\\PhpRedisConnector::establishConnection\(\) expects Redis, Relay\\Relay given\.$#'
     - '#^Return type \(Relay\\Relay\) of method \S+ should be compatible with return type \(Redis\) of method#'
     - '#^PHPDoc type Relay\\Relay of property \S+ is not covariant with PHPDoc type Redis#'
     - '#^Method \S+\\RelayNewRelic::(scan|hscan|sscan|zscan)\(\) should return \S+ but returns mixed#'

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -14,5 +14,5 @@ parameters:
     - '#^Parameter \S+ expects Redis, Relay\\Relay given#'
     - '#^Return type \(Relay\\Relay\) of method \S+ should be compatible with return type \(Redis\) of method#'
     - '#^PHPDoc type Relay\\Relay of property \S+ is not covariant with PHPDoc type Redis#'
-    - '#^Method \S+\\RelayNewRelic::scan\(\) should return \S+ but returns mixed#'
+    - '#^Method \S+\\RelayNewRelic::(scan|hscan|sscan|zscan)\(\) should return \S+ but returns mixed#'
     - '#^Call to an undefined method Redis::(_pack|_unpack)\(\)#'


### PR DESCRIPTION
- from now on it is no secret what we ignore `(scan|hscan|sscan|zscan)`
- run CI on PR-s like this one