### PR TITLE
Improve benchmark output

### DIFF
--- a/benchmarks/Support/Benchmark.php
+++ b/benchmarks/Support/Benchmark.php
@@ -14,6 +14,8 @@ abstract class Benchmark
 
     protected ?string $auth;
 
+    protected bool $socket;
+
     protected Relay $relay;
 
     protected Relay $relayNoCache;
@@ -22,11 +24,12 @@ abstract class Benchmark
 
     protected PhpRedis $phpredis;
 
-    public function __construct(string $host, int $port, ?string $auth)
+    public function __construct(string $host, int $port, ?string $auth, bool $socket)
     {
         $this->host = $host;
         $this->port = $port;
         $this->auth = $auth;
+        $this->socket = $socket;
     }
 
     public function its()
@@ -123,13 +126,20 @@ abstract class Benchmark
 
     protected function createPredis()
     {
-        return new Predis([
+        $parameters = [
             'host' => $this->host,
             'port' => $this->port,
             'password' => $this->auth,
             'timeout' => 0.5,
             'read_write_timeout' => 0.5,
-        ], [
+        ];
+
+        if ($this->socket) {
+            $parameters['scheme'] = 'unix';
+            $parameters['path'] = $this->host;
+        }
+
+        return new Predis($parameters, [
             'exceptions' => true,
         ]);
     }

--- a/benchmarks/Support/CliReporter.php
+++ b/benchmarks/Support/CliReporter.php
@@ -86,9 +86,8 @@ class CliReporter extends Reporter
         $table = new Table($output);
 
         $table->setHeaders([
-            'Client', 'Operation', 'Its', 'Revs',
-            'Memory', 'Network', 'IOPS',
-            'rstdev', 'Time',
+            'Client', 'Memory', 'Network',
+            'IOPS', 'rstdev', 'Time',
             'Speed', 'Decrease',
         ]);
 
@@ -113,9 +112,6 @@ class CliReporter extends Reporter
 
             $table->addRow([
                 $subject->client(),
-                number_format($benchmark->opsTotal()) . ' ' . $benchmark::Name,
-                new TableCell($benchmark->its(), ['style' => new TableCellStyle(['align' => 'right'])]),
-                new TableCell($benchmark->revs(), ['style' => new TableCellStyle(['align' => 'right'])]),
                 new TableCell($this->humanMemory($memoryMedian), ['style' => new TableCellStyle(['align' => 'right'])]),
                 new TableCell($this->humanMemory($bytesMedian), ['style' => new TableCellStyle(['align' => 'right'])]),
                 new TableCell($this->humanNumber($opsMedian), ['style' => new TableCellStyle(['align' => 'right'])]),

--- a/benchmarks/Support/CliReporter.php
+++ b/benchmarks/Support/CliReporter.php
@@ -7,26 +7,23 @@ use ReflectionClass;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableCell;
 use Symfony\Component\Console\Helper\TableCellStyle;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\StreamOutput;
 
 class CliReporter extends Reporter
 {
     public function startingBenchmark(Benchmark $benchmark)
     {
-        $output = new ConsoleOutput();
-
         $reflect = new ReflectionClass($benchmark);
 
-        $output->write(sprintf(
-            "\n<fg=black;bg=green> %s </> Executing %d iterations (%d warmup), %d revolutions of %s %s operations...\n\n",
+        printf(
+            "\n\033[30;42m %s \033[0m Executing %d iterations (%d warmup, %d revs) of %s %s operations...\n\n",
             substr(basename($reflect->getShortName()), 9),
             $benchmark->its(),
             $benchmark::Warmup ?? 'no',
             $benchmark->revs(),
             number_format($benchmark->opsTotal()),
             $benchmark::Name
-        ));
+        );
     }
 
     public function finishedIteration(Iteration $iteration)

--- a/benchmarks/Support/CliReporter.php
+++ b/benchmarks/Support/CliReporter.php
@@ -7,22 +7,26 @@ use ReflectionClass;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableCell;
 use Symfony\Component\Console\Helper\TableCellStyle;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\StreamOutput;
 
 class CliReporter extends Reporter
 {
     public function startingBenchmark(Benchmark $benchmark)
     {
+        $output = new ConsoleOutput();
+
         $reflect = new ReflectionClass($benchmark);
 
-        printf(
-            "\nExecuting `%s` benchmark with %d iterations (%d warmup) of %s %s operations...\n\n",
+        $output->write(sprintf(
+            "\n<fg=black;bg=green> %s </> Executing %d iterations (%d warmup), %d revolutions of %s %s operations...\n\n",
             substr(basename($reflect->getShortName()), 9),
             $benchmark->its(),
             $benchmark::Warmup ?? 'no',
+            $benchmark->revs(),
             number_format($benchmark->opsTotal()),
             $benchmark::Name
-        );
+        ));
     }
 
     public function finishedIteration(Iteration $iteration)

--- a/benchmarks/Support/Runner.php
+++ b/benchmarks/Support/Runner.php
@@ -36,9 +36,9 @@ class Runner
         printf(
             "Using PHP %s (OPcache: %s, Xdebug: %s, New Relic: %s)\n",
             PHP_VERSION,
-            $this->opcache() ? '\033[31mOn\033[0m' : "Off",
-            $this->xdebug() ? '\033[31mOn\033[0m' : "Off",
-            $this->newrelic() ? '\033[31mOn\033[0m' : 'Off'
+            $this->opcache() ? "\033[31mOn\033[0m" : "Off",
+            $this->xdebug() ? "\033[31mOn\033[0m" : "Off",
+            $this->newrelic() ? "\033[31mOn\033[0m" : 'Off'
         );
 
         $this->setUpRedis();

--- a/benchmarks/Support/Runner.php
+++ b/benchmarks/Support/Runner.php
@@ -12,12 +12,15 @@ class Runner
 
     protected ?string $auth;
 
+    protected bool $socket;
+
     protected bool $verbose = false;
 
     protected Predis $redis;
 
-    public function __construct($host, $port, $auth, bool $verbose)
+    public function __construct($host, $port, $auth, bool $socket, bool $verbose)
     {
+        $this->socket = $socket;
         $this->verbose = $verbose;
 
         $this->host = (string) $host;
@@ -44,22 +47,28 @@ class Runner
         $this->setUpRedis();
 
         printf(
-            "Connected to Redis (%s) at tcp://%s:%s\n\n",
+            "Connected to Redis (%s) at %s\n\n",
             $this->redis->info()['Server']['redis_version'],
-            $host,
-            $port
+            $this->socket ? "unix:{$host}" : "tcp://{$host}:{$port}",
         );
     }
 
     protected function setUpRedis()
     {
-        $this->redis = new Predis([
+        $parameters = [
             'host' => $this->host,
             'port' => $this->port,
             'password' => $this->auth,
             'timeout' => 0.5,
             'read_write_timeout' => 0.5,
-        ], [
+        ];
+
+        if ($this->socket) {
+            $parameters['scheme'] = 'unix';
+            $parameters['path'] = $this->host;
+        }
+
+        $this->redis = new Predis($parameters, [
             'exceptions' => true,
         ]);
     }
@@ -67,7 +76,7 @@ class Runner
     public function run(array $benchmarks)
     {
         foreach ($benchmarks as $class) {
-            $benchmark = new $class($this->host, $this->port, $this->auth);
+            $benchmark = new $class($this->host, $this->port, $this->auth, $this->socket);
             $benchmark->setUp();
 
             $subjects = new Subjects($benchmark);

--- a/benchmarks/run
+++ b/benchmarks/run
@@ -22,7 +22,7 @@ $runner = new CacheWerk\Relay\Benchmarks\Support\Runner(
     $opt['s'] ?? $opt['h'] ?? '127.0.0.1',
     $opt['p'] ?? (isset($opt['s']) ? -1 : 6379),
     $opt['a'] ?? null,
-    isset($opt['s']) || isset($opt['socket']),
+    isset($opt['s']),
     isset($opt['v']) || isset($opt['verbose'])
 );
 

--- a/benchmarks/run
+++ b/benchmarks/run
@@ -18,15 +18,19 @@ $benchmarks = array_map(function ($file) {
     throw new InvalidArgumentException('Unable to read file ' . __DIR__ . '/' . $file);
 }, empty($argv) ? glob(__DIR__ . '/Benchmark*.php') : $argv);
 
-$runner = new CacheWerk\Relay\Benchmarks\Support\Runner(
-    $opt['s'] ?? $opt['h'] ?? '127.0.0.1',
-    $opt['p'] ?? (isset($opt['s']) ? -1 : 6379),
-    $opt['a'] ?? null,
-    isset($opt['s']),
-    isset($opt['v']) || isset($opt['verbose'])
-);
+try {
+    $runner = new CacheWerk\Relay\Benchmarks\Support\Runner(
+        $opt['s'] ?? $opt['h'] ?? '127.0.0.1',
+        $opt['p'] ?? (isset($opt['s']) ? -1 : 6379),
+        $opt['a'] ?? null,
+        isset($opt['s']),
+        isset($opt['v']) || isset($opt['verbose'])
+    );
 
-$runner->run($benchmarks);
+    $runner->run($benchmarks);
+} catch (\Exception $exception) {
+    printf("\n\033[41m ERROR \033[0m {$exception->getMessage()}\n");
+}
 
 // TODO: support PHP 7.4
 // TODO: test `-a` password parameter

--- a/benchmarks/run
+++ b/benchmarks/run
@@ -22,6 +22,7 @@ $runner = new CacheWerk\Relay\Benchmarks\Support\Runner(
     $opt['s'] ?? $opt['h'] ?? '127.0.0.1',
     $opt['p'] ?? (isset($opt['s']) ? -1 : 6379),
     $opt['a'] ?? null,
+    isset($opt['s']) || isset($opt['socket']),
     isset($opt['v']) || isset($opt['verbose'])
 );
 


### PR DESCRIPTION
Till, I had to make a few changes to get sockets working. There was also an issue with the color output for me locally as I was seeing `\033[31mOn\033[0m` printed to the terminal for xdebug.

The one thing that I'm not sure about is the "Decrease" column. The "Speed" column seems like the better metric. 

<img width="849" alt="CleanShot 2023-05-25 at 14 34 33@2x" src="https://github.com/cachewerk/relay/assets/1422996/9ddf9dc0-6aa5-4d88-b8a1-308a2526f250">

Cleaned up exceptions:

<img width="629" alt="CleanShot 2023-05-25 at 16 13 32@2x" src="https://github.com/cachewerk/relay/assets/1422996/da5a8e72-71b7-4814-838b-2ccad0445352">

- [x] Test `-a` password parameter
- [x] Test `-s` socket parameter