### PR TITLE
Explain about installing PhpRedis

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,5 +1,10 @@
 # Relay Benchmarks
 
+## Requirements
+
+- PHP 7.4+
+- Redis 6.0+
+
 ## Installation
 
 First, follow the [installation instructions](https://relay.so/docs/installation) to set up the Relay extension for PHP.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,6 +4,8 @@
 
 First, follow the [installation instructions](https://relay.so/docs/installation) to set up the Relay extension for PHP.
 
+Make sure you have [installed PhpRedis](https://github.com/phpredis/phpredis/blob/develop/INSTALL.md) and, of course, [Redis itself](https://redis.io/docs/getting-started/installation/).
+
 Next, clone the Relay repository and install the Composer dependencies:
 
 ```bash

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,7 +4,7 @@
 
 First, follow the [installation instructions](https://relay.so/docs/installation) to set up the Relay extension for PHP.
 
-Make sure you have [installed PhpRedis](https://github.com/phpredis/phpredis/blob/develop/INSTALL.md) and, of course, [Redis itself](https://redis.io/docs/getting-started/installation/).
+Make sure you have [installed PhpRedis](https://github.com/phpredis/phpredis/blob/develop/INSTALL.md) and, of course, [Redis itself](https://redis.io/docs/getting-started/installation/). When installing PhpRedis, say *yes* to all prompts about `enable igbinary serializer support` etc.
 
 Next, clone the Relay repository and install the Composer dependencies:
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,8 +9,6 @@
 
 First, follow the [installation instructions](https://relay.so/docs/installation) to set up the Relay extension for PHP.
 
-Make sure you have [installed PhpRedis](https://github.com/phpredis/phpredis/blob/develop/INSTALL.md) and, of course, [Redis itself](https://redis.io/docs/getting-started/installation/). When installing PhpRedis, say *yes* to all prompts about `enable igbinary serializer support` etc.
-
 Next, clone the Relay repository and install the Composer dependencies:
 
 ```bash


### PR DESCRIPTION
When I tried following these instructions, I got an error because I hadn't yet installed PhpRedis.

This adds something to the docs to help avoid this in future.