### PR TITLE
Remove Ubuntu 18 from CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,7 +89,6 @@ jobs:
           - centos8/centos8-dnf
           - el9/el9-dnf
           - debian/debian11-apt
-          - ubuntu/ubuntu18-apt
           - ubuntu/ubuntu22-apt
 
     services:


### PR DESCRIPTION
Fails for 2 weeks now.

From https://github.com/cachewerk/relay/commit/825ee88c3b0d7fbec3c8d73348668fdf1232d1b2
