### PR TITLE
Abort if relay extension is not installed

### DIFF
--- a/benchmarks/run
+++ b/benchmarks/run
@@ -1,14 +1,13 @@
 #!/usr/bin/env php
 <?php
 
-
 namespace CacheWerk\Relay\Benchmarks;
 
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
 
 if (! extension_loaded('relay')) {
-    fprintf(STDERR, "\n\033[41m ERROR \033[0m Unable to find relay extension, follow the \e]8;;https://relay.so/docs/installation\e\\installation instructions\e]8;;\e\\ to set up it.\n");
+    fprintf(STDERR, "\n\033[41m ERROR \033[0m The `relay` extension is not loaded in this PHP environment.\n");
     exit(1);
 }
 

--- a/benchmarks/run
+++ b/benchmarks/run
@@ -7,6 +7,11 @@ namespace CacheWerk\Relay\Benchmarks;
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
 
+if (! extension_loaded('relay')) {
+    fprintf(STDERR, "\n\033[41m ERROR \033[0m Unable to find relay extension, follow the \e]8;;https://relay.so/docs/installation\e\\installation instructions\e]8;;\e\\ to set up it.\n");
+    exit(1);
+}
+
 if (! is_readable(__DIR__ . '/../vendor/autoload.php')) {
     fprintf(STDERR, "\n\033[41m ERROR \033[0m Unable to locate autoloader, please run `composer install`\n");
     exit(1);


### PR DESCRIPTION
Added check, that `relay` extension is loaded before run any tests.
`instalation instruction` is clickable link to `https://relay.so/docs/installation`

![image](https://github.com/cachewerk/relay/assets/1374472/ad5b89fb-3aa4-4ab2-9b1c-612fcef4daa9)
