### PR TITLE
Move methods to base class

### DIFF
--- a/benchmarks/Cases/BenchmarkHmget.php
+++ b/benchmarks/Cases/BenchmarkHmget.php
@@ -39,24 +39,4 @@ class BenchmarkHmget extends BenchmarkHashCommand
 
         return count($this->keys);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkHmset.php
+++ b/benchmarks/Cases/BenchmarkHmset.php
@@ -50,24 +50,4 @@ class BenchmarkHmset extends Benchmark
 
         return count($this->data);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkLrange.php
+++ b/benchmarks/Cases/BenchmarkLrange.php
@@ -47,24 +47,4 @@ class BenchmarkLrange extends Benchmark
 
         return count($this->keys);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkMget.php
+++ b/benchmarks/Cases/BenchmarkMget.php
@@ -53,24 +53,4 @@ class BenchmarkMget extends Benchmark
 
         return count($this->keyChunks);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkMset.php
+++ b/benchmarks/Cases/BenchmarkMset.php
@@ -56,24 +56,4 @@ class BenchmarkMset extends Benchmark
 
         return count($this->keyChunks);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkRpush.php
+++ b/benchmarks/Cases/BenchmarkRpush.php
@@ -55,19 +55,4 @@ class BenchmarkRpush extends Benchmark
 
         return count($this->data);
     }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkSadd.php
+++ b/benchmarks/Cases/BenchmarkSadd.php
@@ -50,24 +50,4 @@ class BenchmarkSadd extends Benchmark
 
         return count($this->data);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkSet.php
+++ b/benchmarks/Cases/BenchmarkSet.php
@@ -50,24 +50,4 @@ class BenchmarkSet extends Benchmark
 
         return count($this->data);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkSinter.php
+++ b/benchmarks/Cases/BenchmarkSinter.php
@@ -68,24 +68,4 @@ class BenchmarkSinter extends Benchmark
 
         return count($this->keyChunks);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkSismember.php
+++ b/benchmarks/Cases/BenchmarkSismember.php
@@ -27,24 +27,4 @@ class BenchmarkSismember extends BenchmarkSetCommand
 
         return count($this->keys) * count($this->mems);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkSmismember.php
+++ b/benchmarks/Cases/BenchmarkSmismember.php
@@ -35,19 +35,4 @@ class BenchmarkSmismember extends BenchmarkSetCommand
 
         return count($this->keys);
     }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkSrandmember.php
+++ b/benchmarks/Cases/BenchmarkSrandmember.php
@@ -25,24 +25,4 @@ class BenchmarkSrandmember extends BenchmarkSetCommand
 
         return count($this->keys);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkZadd.php
+++ b/benchmarks/Cases/BenchmarkZadd.php
@@ -59,24 +59,4 @@ class BenchmarkZadd extends Benchmark
 
         return count($this->data);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkZincrby.php
+++ b/benchmarks/Cases/BenchmarkZincrby.php
@@ -61,24 +61,4 @@ class BenchmarkZincrby extends Benchmark
 
         return $operations;
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Cases/BenchmarkZrange.php
+++ b/benchmarks/Cases/BenchmarkZrange.php
@@ -56,24 +56,4 @@ class BenchmarkZrange extends Benchmark
 
         return count($this->keys);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Support/Benchmark.php
+++ b/benchmarks/Support/Benchmark.php
@@ -237,4 +237,24 @@ abstract class Benchmark
             }
         );
     }
+
+    public function benchmarkPredis(): int
+    {
+        return $this->runBenchmark($this->predis);
+    }
+
+    public function benchmarkPhpRedis(): int
+    {
+        return $this->runBenchmark($this->phpredis);
+    }
+
+    public function benchmarkRelayNoCache(): int
+    {
+        return $this->runBenchmark($this->relayNoCache);
+    }
+
+    public function benchmarkRelay(): int
+    {
+        return $this->runBenchmark($this->relay);
+    }
 }

--- a/benchmarks/Support/BenchmarkKeyCommand.php
+++ b/benchmarks/Support/BenchmarkKeyCommand.php
@@ -36,24 +36,4 @@ abstract class BenchmarkKeyCommand extends Benchmark
 
         return count($this->keys);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }

--- a/benchmarks/Support/BenchmarkStringRangeCommand.php
+++ b/benchmarks/Support/BenchmarkStringRangeCommand.php
@@ -76,24 +76,4 @@ abstract class BenchmarkStringRangeCommand extends Benchmark
 
         return count($this->args);
     }
-
-    public function benchmarkPredis(): int
-    {
-        return $this->runBenchmark($this->predis);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
-    }
 }


### PR DESCRIPTION
PHP allows to use methods from parent class)