### PR TITLE
Skip PhpRedis tests when redis extension is not installed

### DIFF
--- a/benchmarks/Cases/BenchmarkZstdIgbinary.php
+++ b/benchmarks/Cases/BenchmarkZstdIgbinary.php
@@ -60,12 +60,18 @@ class BenchmarkZstdIgbinary extends Benchmark
      */
     protected function setSerialization($client): void
     {
-        if (! $client->setOption(Relay::OPT_SERIALIZER, Relay::SERIALIZER_IGBINARY)) {
-            Reporter::printWarning(sprintf('Unable to set igbinary serializer on %s', get_class($client)));
+        $className = get_class($client);
+
+        if (! defined("{$className}::SERIALIZER_IGBINARY") ||
+            ! $client->setOption($client::OPT_SERIALIZER, $client::SERIALIZER_IGBINARY)
+        ) {
+            Reporter::printWarning("Unable to set igbinary serializer on {$className}");
         }
 
-        if (! $client->setOption(Relay::OPT_COMPRESSION, Relay::COMPRESSION_ZSTD)) {
-            Reporter::printWarning(sprintf('Unable to set zstd compression on %s', get_class($client)));
+        if (! defined("{$className}::COMPRESSION_ZSTD") ||
+            ! $client->setOption($client::OPT_COMPRESSION, $client::COMPRESSION_ZSTD)
+        ) {
+            Reporter::printWarning("Unable to set zstd compression on {$className}");
         }
     }
 

--- a/benchmarks/Cases/BenchmarkZstdIgbinary.php
+++ b/benchmarks/Cases/BenchmarkZstdIgbinary.php
@@ -49,6 +49,7 @@ class BenchmarkZstdIgbinary extends Benchmark
 
         $this->seedClient($this->predis, $items, true);
         $this->seedClient($this->relayNoCache, $items);
+
         if (extension_loaded('redis')) {
             $this->seedClient($this->phpredis, $items);
         }
@@ -71,10 +72,12 @@ class BenchmarkZstdIgbinary extends Benchmark
     public function setUpClients(): void
     {
         parent::setUpClients();
+
         $clients = [
             $this->relayNoCache,
             $this->relay,
         ];
+
         if (extension_loaded('redis')) {
             $clients[] = $this->phpredis;
         }
@@ -87,6 +90,7 @@ class BenchmarkZstdIgbinary extends Benchmark
     public function refreshClients(): void
     {
         parent::refreshClients();
+
         if (extension_loaded('redis')) {
             $this->setSerialization($this->phpredis);
         }

--- a/benchmarks/Cases/BenchmarkZstdIgbinary.php
+++ b/benchmarks/Cases/BenchmarkZstdIgbinary.php
@@ -2,11 +2,10 @@
 
 namespace CacheWerk\Relay\Benchmarks\Cases;
 
-use Redis;
 use Relay\Relay;
 
-use CacheWerk\Relay\Benchmarks\Support\Benchmark;
 use CacheWerk\Relay\Benchmarks\Support\Reporter;
+use CacheWerk\Relay\Benchmarks\Support\Benchmark;
 
 class BenchmarkZstdIgbinary extends Benchmark
 {
@@ -61,11 +60,12 @@ class BenchmarkZstdIgbinary extends Benchmark
      */
     protected function setSerialization($client): void
     {
-        if (! $client->setOption(Relay::OPT_SERIALIZER, Relay::SERIALIZER_IGBINARY)) {
-            Reporter::printWarning('Failed to set igbinary serializer');
+        if (! $client->setOption($client::OPT_SERIALIZER, $client::SERIALIZER_IGBINARY)) {
+            Reporter::printWarning(sprintf('Unable to set igbinary serializer on %s', get_class($client)));
         }
-        if (! $client->setOption(Relay::OPT_COMPRESSION, Relay::COMPRESSION_ZSTD)) {
-            Reporter::printWarning('Failed to enable zstd compression');
+
+        if (! $client->setOption($client::OPT_COMPRESSION, $client::COMPRESSION_ZSTD)) {
+            Reporter::printWarning(sprintf('Unable to set zstd compression on %s', get_class($client)));
         }
     }
 

--- a/benchmarks/Cases/BenchmarkZstdIgbinary.php
+++ b/benchmarks/Cases/BenchmarkZstdIgbinary.php
@@ -60,11 +60,11 @@ class BenchmarkZstdIgbinary extends Benchmark
      */
     protected function setSerialization($client): void
     {
-        if (! $client->setOption($client::OPT_SERIALIZER, $client::SERIALIZER_IGBINARY)) {
+        if (! $client->setOption(Relay::OPT_SERIALIZER, Relay::SERIALIZER_IGBINARY)) {
             Reporter::printWarning(sprintf('Unable to set igbinary serializer on %s', get_class($client)));
         }
 
-        if (! $client->setOption($client::OPT_COMPRESSION, $client::COMPRESSION_ZSTD)) {
+        if (! $client->setOption(Relay::OPT_COMPRESSION, Relay::COMPRESSION_ZSTD)) {
             Reporter::printWarning(sprintf('Unable to set zstd compression on %s', get_class($client)));
         }
     }
@@ -117,21 +117,6 @@ class BenchmarkZstdIgbinary extends Benchmark
     public function benchmarkPredis(): int
     {
         return $this->runBenchmark($this->predis, true);
-    }
-
-    public function benchmarkPhpRedis(): int
-    {
-        return $this->runBenchmark($this->phpredis);
-    }
-
-    public function benchmarkRelayNoCache(): int
-    {
-        return $this->runBenchmark($this->relayNoCache);
-    }
-
-    public function benchmarkRelay(): int
-    {
-        return $this->runBenchmark($this->relay);
     }
 
     /**

--- a/benchmarks/Cases/BenchmarkZstdIgbinary.php
+++ b/benchmarks/Cases/BenchmarkZstdIgbinary.php
@@ -6,6 +6,7 @@ use Redis;
 use Relay\Relay;
 
 use CacheWerk\Relay\Benchmarks\Support\Benchmark;
+use CacheWerk\Relay\Benchmarks\Support\Reporter;
 
 class BenchmarkZstdIgbinary extends Benchmark
 {
@@ -59,8 +60,12 @@ class BenchmarkZstdIgbinary extends Benchmark
      */
     protected function setSerialization($client): void
     {
-        $client->setOption(Relay::OPT_SERIALIZER, Relay::SERIALIZER_IGBINARY);
-        $client->setOption(Relay::OPT_COMPRESSION, Relay::COMPRESSION_ZSTD);
+        if (! $client->setOption(Relay::OPT_SERIALIZER, Relay::SERIALIZER_IGBINARY)) {
+            Reporter::printWarning('Failed to set igbinary serializer');
+        }
+        if (! $client->setOption(Relay::OPT_COMPRESSION, Relay::COMPRESSION_ZSTD)) {
+            Reporter::printWarning('Failed to enable zstd compression');
+        }
     }
 
     public function setUpClients(): void

--- a/benchmarks/Support/Benchmark.php
+++ b/benchmarks/Support/Benchmark.php
@@ -265,7 +265,15 @@ abstract class Benchmark
 
                 $method = substr($method, strlen('benchmark'));
 
-                return (! $exclude || $method !== $exclude) && (! $filter || preg_match("/$filter/i", strtolower($method)));
+                if ($exclude && $method === $exclude) {
+                    return false;
+                }
+
+                if ($filter && ! preg_match("/$filter/i", strtolower($method))) {
+                    return false;
+                }
+
+                return true;
             }
         );
     }

--- a/benchmarks/Support/Benchmark.php
+++ b/benchmarks/Support/Benchmark.php
@@ -132,7 +132,7 @@ abstract class Benchmark
         $data = file_get_contents($file);
 
         if (! is_string($data)) {
-            throw new Exception("Failed to load data file '$file'");
+            throw new Exception("Failed to load data file `{$file}`");
         }
 
         return json_decode((string) $data, $assoc, 512, JSON_THROW_ON_ERROR);
@@ -252,8 +252,9 @@ abstract class Benchmark
         $exclude = null;
 
         if (! extension_loaded('redis')) {
-            Reporter::printWarning('Skip all PhpRedis tests because redis extension is not loaded');
             $exclude = 'PhpRedis';
+
+            Reporter::printWarning('Skipping PhpRedis runs, extension is not loaded');
         }
 
         return array_filter(
@@ -265,11 +266,11 @@ abstract class Benchmark
 
                 $method = substr($method, strlen('benchmark'));
 
-                if ($exclude && $method === $exclude) {
+                if ($method === $exclude) {
                     return false;
                 }
 
-                if ($filter && ! preg_match("/$filter/i", strtolower($method))) {
+                if ($filter && ! preg_match("/{$filter}/i", strtolower($method))) {
                     return false;
                 }
 

--- a/benchmarks/Support/Benchmark.php
+++ b/benchmarks/Support/Benchmark.php
@@ -249,6 +249,7 @@ abstract class Benchmark
     {
         $exclude = null;
         if (! extension_loaded('redis')) {
+            Reporter::printWarning('Skip all PhpRedis tests because redis extension is not loaded');
             $exclude = 'PhpRedis';
         }
         return array_filter(

--- a/benchmarks/Support/Benchmark.php
+++ b/benchmarks/Support/Benchmark.php
@@ -143,6 +143,7 @@ abstract class Benchmark
         $this->predis = $this->createPredis();
         $this->relay = $this->createRelay();
         $this->relayNoCache = $this->createRelayNoCache();
+
         if (extension_loaded('redis')) {
             $this->phpredis = $this->createPhpRedis();
         }
@@ -158,6 +159,7 @@ abstract class Benchmark
     public function refreshClients(): void
     {
         $this->predis = $this->createPredis();
+
         if (extension_loaded('redis')) {
             $this->phpredis = $this->createPhpRedis();
         }
@@ -248,10 +250,12 @@ abstract class Benchmark
     public function getBenchmarkMethods(string $filter): array
     {
         $exclude = null;
+
         if (! extension_loaded('redis')) {
             Reporter::printWarning('Skip all PhpRedis tests because redis extension is not loaded');
             $exclude = 'PhpRedis';
         }
+
         return array_filter(
             get_class_methods($this),
             function ($method) use ($exclude, $filter) {

--- a/benchmarks/Support/Reporter.php
+++ b/benchmarks/Support/Reporter.php
@@ -50,13 +50,23 @@ abstract class Reporter
         ) . ['', 'K', 'M', 'B'][$i];
     }
 
-    public static function printWarning(string $fmt, bool|float|int|string|null ...$args): void
+    /**
+     * @param  string  $fmt
+     * @param  (bool|float|int|string|null)[]  $args
+     * @return void
+     */
+    public static function printWarning(string $fmt, ...$args): void
     {
-        fprintf(STDERR, "\n\033[33m WARNING \033[0m $fmt\n", ...$args);
+        fprintf(STDERR, "\n\033[33m WARNING \033[0m {$fmt}\n", ...$args);
     }
 
-    public static function printError(string $fmt, bool|float|int|string|null ...$args): void
+    /**
+     * @param  string  $fmt
+     * @param  (bool|float|int|string|null)[]  $args
+     * @return void
+     */
+    public static function printError(string $fmt, ...$args): void
     {
-        fprintf(STDERR, "\n\033[41m ERROR \033[0m $fmt\n", ...$args);
+        fprintf(STDERR, "\n\033[41m ERROR \033[0m {$fmt}\n", ...$args);
     }
 }

--- a/benchmarks/Support/Reporter.php
+++ b/benchmarks/Support/Reporter.php
@@ -50,6 +50,11 @@ abstract class Reporter
         ) . ['', 'K', 'M', 'B'][$i];
     }
 
+    public static function printWarning(string $fmt, bool|float|int|string|null ...$args): void
+    {
+        fprintf(STDERR, "\n\033[33m WARNING \033[0m $fmt\n", ...$args);
+    }
+
     public static function printError(string $fmt, bool|float|int|string|null ...$args): void
     {
         fprintf(STDERR, "\n\033[41m ERROR \033[0m $fmt\n", ...$args);

--- a/benchmarks/Support/Reporter.php
+++ b/benchmarks/Support/Reporter.php
@@ -52,7 +52,7 @@ abstract class Reporter
 
     /**
      * @param  string  $fmt
-     * @param  (bool|float|int|string|null)[]  $args
+     * @param  bool|float|int|string|null  ...$args
      * @return void
      */
     public static function printWarning(string $fmt, ...$args): void
@@ -62,7 +62,7 @@ abstract class Reporter
 
     /**
      * @param  string  $fmt
-     * @param  (bool|float|int|string|null)[]  $args
+     * @param  bool|float|int|string|null  ...$args
      * @return void
      */
     public static function printError(string $fmt, ...$args): void


### PR DESCRIPTION
Simplest implementation with check whether `redis` extension loaded before acting with `phpredis` property