### PR TITLE
Include every "length" command + generic way to set typed keys

### DIFF
--- a/benchmarks/Cases/BenchmarkHlen.php
+++ b/benchmarks/Cases/BenchmarkHlen.php
@@ -4,10 +4,10 @@ namespace CacheWerk\Relay\Benchmarks\Cases;
 
 use CacheWerk\Relay\Benchmarks\Support\BenchmarkLenCommand;
 
-class BenchmarkSCARD extends BenchmarkLenCommand
+class BenchmarkHLEN extends BenchmarkLenCommand
 {
     public static function flags(): int
     {
-        return self::SET | self::READ;
+        return self::HASH | self::READ;
     }
 }

--- a/benchmarks/Cases/BenchmarkLlen.php
+++ b/benchmarks/Cases/BenchmarkLlen.php
@@ -4,10 +4,10 @@ namespace CacheWerk\Relay\Benchmarks\Cases;
 
 use CacheWerk\Relay\Benchmarks\Support\BenchmarkLenCommand;
 
-class BenchmarkSCARD extends BenchmarkLenCommand
+class BenchmarkLLEN extends BenchmarkLenCommand
 {
     public static function flags(): int
     {
-        return self::SET | self::READ;
+        return self::LIST | self::READ;
     }
 }

--- a/benchmarks/Cases/BenchmarkStrlen.php
+++ b/benchmarks/Cases/BenchmarkStrlen.php
@@ -4,10 +4,10 @@ namespace CacheWerk\Relay\Benchmarks\Cases;
 
 use CacheWerk\Relay\Benchmarks\Support\BenchmarkLenCommand;
 
-class BenchmarkSCARD extends BenchmarkLenCommand
+class BenchmarkSTRLEN extends BenchmarkLenCommand
 {
     public static function flags(): int
     {
-        return self::SET | self::READ;
+        return self::STRING | self::READ;
     }
 }

--- a/benchmarks/Cases/BenchmarkZcard.php
+++ b/benchmarks/Cases/BenchmarkZcard.php
@@ -4,10 +4,10 @@ namespace CacheWerk\Relay\Benchmarks\Cases;
 
 use CacheWerk\Relay\Benchmarks\Support\BenchmarkLenCommand;
 
-class BenchmarkSCARD extends BenchmarkLenCommand
+class BenchmarkZCARD extends BenchmarkLenCommand
 {
     public static function flags(): int
     {
-        return self::SET | self::READ;
+        return self::ZSET | self::READ;
     }
 }

--- a/benchmarks/Support/BenchmarkLenCommand.php
+++ b/benchmarks/Support/BenchmarkLenCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Support;
+
+use CacheWerk\Relay\Benchmarks\Support\BenchmarkKeyCommand;
+
+abstract class BenchmarkLenCommand extends BenchmarkKeyCommand
+{
+    /**
+     * @var array<int, string>
+     */
+    protected array $keys;
+
+    public function setUp(): void
+    {
+        $this->flush();
+        $this->setUpClients();
+        $this->seed();
+    }
+
+    public function seed(): void
+    {
+        $this->keys = $this->seedSimpleKeys();
+    }
+}


### PR DESCRIPTION
* Relay caches in-memory the "length" information about keys of any type, so we should include all of these commands in our benchmark suite.

* Add a generic helper method that uses our flags to set keys of a given type in a generic way.