### PR TITLE
Add GETBIT, HEXISTS, HGET, HKEYS, HRANDFIELD, HVALS, and HSTRLEN benc…

### DIFF
--- a/benchmarks/Cases/BenchmarkGetbit.php
+++ b/benchmarks/Cases/BenchmarkGetbit.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Cases;
+
+use CacheWerk\Relay\Benchmarks\Support\Benchmark;
+
+class BenchmarkGETBIT extends Benchmark
+{
+    /**
+     * @var array<int, string>
+     */
+    protected array $keys;
+
+    public function setUp(): void
+    {
+        $this->flush();
+        $this->setUpClients();
+        $this->seed();
+    }
+
+    public function seed(): void
+    {
+        $this->keys = $this->seedSimpleKeys();
+    }
+
+    public static function flags(): int
+    {
+        return self::STRING | self::READ;
+    }
+
+    public function warmup(int $times, string $method): void
+    {
+        if ($times == 0) {
+            return;
+        }
+
+        parent::warmup($times, $method);
+
+        $this->readSimpleKeys($this->keys);
+    }
+
+    public function runBenchmark($client): int {
+        foreach ($this->keys as $i => $key) {
+            $client->getbit($key, $i);
+        }
+
+        return count($this->keys);
+    }
+}

--- a/benchmarks/Cases/BenchmarkHexists.php
+++ b/benchmarks/Cases/BenchmarkHexists.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Cases;
+
+use CacheWerk\Relay\Benchmarks\Support\BenchmarkHashCommand;
+
+class BenchmarkHEXISTS extends BenchmarkHashCommand
+{
+    const MemsPerCommand = 4;
+
+    /**
+     * @var array<int, string>
+     */
+    protected array $queryMems;
+
+    public static function flags(): int
+    {
+        return self::HASH | self::READ;
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->queryMems = array_slice($this->mems, 0, self::MemsPerCommand);
+    }
+
+    /**
+     * @param  \Redis|\Relay\Relay|\Predis\Client  $client
+     * @return int
+     */
+    protected function runBenchmark($client): int
+    {
+        foreach ($this->keys as $i => $key) {
+            $client->hexists($key, $this->queryMems[$i % count($this->queryMems)]);
+        }
+
+        return count($this->keys);
+    }
+}

--- a/benchmarks/Cases/BenchmarkHget.php
+++ b/benchmarks/Cases/BenchmarkHget.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Cases;
+
+use CacheWerk\Relay\Benchmarks\Support\BenchmarkHashCommand;
+
+class BenchmarkHGET extends BenchmarkHashCommand
+{
+    const MemsPerCommand = 4;
+
+    /**
+     * @var array<int, string>
+     */
+    protected array $queryMems;
+
+    public static function flags(): int
+    {
+        return self::HASH | self::READ;
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->queryMems = array_slice($this->mems, 0, self::MemsPerCommand);
+    }
+
+    /**
+     * @param  \Redis|\Relay\Relay|\Predis\Client  $client
+     * @return int
+     */
+    protected function runBenchmark($client): int
+    {
+        foreach ($this->keys as $i => $key) {
+            $client->hget($key, $this->queryMems[$i % count($this->queryMems)]);
+        }
+
+        return count($this->keys);
+    }
+}

--- a/benchmarks/Cases/BenchmarkHkeys.php
+++ b/benchmarks/Cases/BenchmarkHkeys.php
@@ -4,7 +4,7 @@ namespace CacheWerk\Relay\Benchmarks\Cases;
 
 use CacheWerk\Relay\Benchmarks\Support\BenchmarkHashKeyCommand;
 
-class BenchmarkHGETALL extends BenchmarkHashKeyCommand
+class BenchmarkHKEYS extends BenchmarkHashKeyCommand
 {
     //
 }

--- a/benchmarks/Cases/BenchmarkHrandfield.php
+++ b/benchmarks/Cases/BenchmarkHrandfield.php
@@ -4,7 +4,7 @@ namespace CacheWerk\Relay\Benchmarks\Cases;
 
 use CacheWerk\Relay\Benchmarks\Support\BenchmarkHashKeyCommand;
 
-class BenchmarkHGETALL extends BenchmarkHashKeyCommand
+class BenchmarkHRANDFIELD extends BenchmarkHashKeyCommand
 {
     //
 }

--- a/benchmarks/Cases/BenchmarkHstrlen.php
+++ b/benchmarks/Cases/BenchmarkHstrlen.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Cases;
+
+use CacheWerk\Relay\Benchmarks\Support\BenchmarkHashCommand;
+
+class BenchmarkHSTRLEN extends BenchmarkHashCommand
+{
+    const MemsPerCommand = 4;
+
+    /**
+     * @var array<int, string>
+     */
+    protected array $queryMems;
+
+    public static function flags(): int
+    {
+        return self::HASH | self::READ;
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->queryMems = array_slice($this->mems, 0, self::MemsPerCommand);
+    }
+
+    /**
+     * @param  \Redis|\Relay\Relay|\Predis\Client  $client
+     * @return int
+     */
+    protected function runBenchmark($client): int
+    {
+        foreach ($this->keys as $i => $key) {
+            $client->hstrlen($key, $this->queryMems[$i % count($this->queryMems)]);
+        }
+
+        return count($this->keys);
+    }
+}

--- a/benchmarks/Cases/BenchmarkHvals.php
+++ b/benchmarks/Cases/BenchmarkHvals.php
@@ -4,7 +4,7 @@ namespace CacheWerk\Relay\Benchmarks\Cases;
 
 use CacheWerk\Relay\Benchmarks\Support\BenchmarkHashKeyCommand;
 
-class BenchmarkHGETALL extends BenchmarkHashKeyCommand
+class BenchmarkHVALS extends BenchmarkHashKeyCommand
 {
     //
 }

--- a/benchmarks/Cases/BenchmarkSinter.php
+++ b/benchmarks/Cases/BenchmarkSinter.php
@@ -34,9 +34,7 @@ class BenchmarkSINTER extends Benchmark
         parent::warmup($times, $method);
 
         foreach ($this->keyChunks as $chunk) {
-            foreach ($chunk as $key) {
-                $this->relay->smembers((string) $key);
-            }
+            $this->readSimpleKeys($chunk);
         }
     }
 

--- a/benchmarks/Support/Benchmark.php
+++ b/benchmarks/Support/Benchmark.php
@@ -145,7 +145,8 @@ abstract class Benchmark
      *
      * @return string[] An array of string key names.
      **/
-    protected function seedSimpleKeys(): array {
+    protected function seedSimpleKeys(): array
+    {
         $keys = [];
 
         $redis = $this->createPredis();
@@ -174,6 +175,28 @@ abstract class Benchmark
         }
 
         return $keys;
+    }
+
+    /**
+     * Generic function to read an entire key based on the Benchmark's specified key type.
+     *
+     * @param array<int, int|string> $keys
+     */
+    public function readSimpleKeys($keys): void
+    {
+        foreach ($keys as $key) {
+            if ($this->flags() & Self::STRING) {
+                $this->relay->get($key);
+            } else if ($this->flags() & Self::LIST) {
+                $this->relay->lrange($key, 0, -1);
+            } else if ($this->flags() & Self::HASH) {
+                $this->relay->hgetall($key);
+            } else if ($this->flags() & Self::SET) {
+                $this->relay->smembers($key);
+            } else {
+                throw new Exception("Unsupported key type");
+            }
+        }
     }
 
     public function setUpClients(): void

--- a/benchmarks/Support/BenchmarkHashCommand.php
+++ b/benchmarks/Support/BenchmarkHashCommand.php
@@ -29,9 +29,7 @@ abstract class BenchmarkHashCommand extends Benchmark
 
         parent::warmup($times, $method);
 
-        foreach ($this->keys as $key) {
-            $this->relay->hgetall((string) $key);
-        }
+        $this->readSimpleKeys($this->keys);
     }
 
     public function seed(): void

--- a/benchmarks/Support/BenchmarkHashKeyCommand.php
+++ b/benchmarks/Support/BenchmarkHashKeyCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Support;
+
+use CacheWerk\Relay\Benchmarks\Support\BenchmarkKeyCommand;
+
+class BenchmarkHashKeyCommand extends BenchmarkKeyCommand
+{
+    /**
+     * @var array<int, string>
+     */
+    protected array $keys;
+
+    public static function flags(): int
+    {
+        return self::HASH | self::READ;
+    }
+
+    public function setUp(): void
+    {
+        $this->flush();
+        $this->setUpClients();
+        $this->seed();
+    }
+
+    public function warmup(int $times, string $method): void
+    {
+        if ($times == 0) {
+            return;
+        }
+
+        parent::warmup($times, $method);
+        $this->readSimpleKeys($this->keys);
+    }
+
+    public function seed(): void
+    {
+        $this->keys = $this->seedSimpleKeys();
+    }
+}

--- a/benchmarks/Support/BenchmarkSetCommand.php
+++ b/benchmarks/Support/BenchmarkSetCommand.php
@@ -29,9 +29,7 @@ abstract class BenchmarkSetCommand extends Benchmark
 
         parent::warmup($times, $method);
 
-        foreach ($this->keys as $key) {
-            $this->relay->smembers((string) $key);
-        }
+        $this->readSimpleKeys($this->keys);
     }
 
     public function seed(): void

--- a/benchmarks/Support/BenchmarkStringRangeCommand.php
+++ b/benchmarks/Support/BenchmarkStringRangeCommand.php
@@ -43,9 +43,7 @@ abstract class BenchmarkStringRangeCommand extends Benchmark
 
         parent::warmup($times, $method);
 
-        foreach (array_keys($this->args) as $key) {
-            $this->relay->get((string) $key);
-        }
+        $this->readSimpleKeys(array_keys($this->args));
     }
 
     /**


### PR DESCRIPTION
…hmarks.

* Add GETBIT benchmark.

* Add the remaining hash commands that Relay can read from its in-memory cache.

* Add a helper method to read in entire keys based on the benchmark key type.

* Add a new helper class for commands operating against an entire hash key.