### PR TITLE
Replace relay-pkg.so with relay.so in Dockerfile for CentOS 8

### DIFF
--- a/docker/centos8/centos8.Dockerfile
+++ b/docker/centos8/centos8.Dockerfile
@@ -20,6 +20,11 @@ ENV PHP_EXT_DIR=/opt/remi/php80/root/usr/lib64/php/modules/
 
 ARG RELAY=v0.6.6
 
+# Install Relay dependencies
+RUN yum install -y \
+  http://download.opensuse.org/pub/opensuse/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.6.x86_64.rpm \
+  http://download.opensuse.org/pub/opensuse/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.11.x86_64.rpm
+
 # Relay requires the `msgpack` and `igbinary` extension
 RUN yum install -y \
   php80-php-igbinary \
@@ -32,7 +37,7 @@ RUN PLATFORM=$(uname -m | sed 's/_/-/') \
 # Copy relay.{so,ini}
 RUN PLATFORM=$(uname -m | sed 's/_/-/') \
   && cp "/tmp/relay-$RELAY-php8.0-centos8-$PLATFORM/relay.ini" "$PHP_INI_DIR/50-relay.ini" \
-  && cp "/tmp/relay-$RELAY-php8.0-centos8-$PLATFORM/relay-pkg.so" "$PHP_EXT_DIR/relay.so"
+  && cp "/tmp/relay-$RELAY-php8.0-centos8-$PLATFORM/relay.so" "$PHP_EXT_DIR/relay.so"
 
 # Inject UUID
 RUN sed -i "s/00000000-0000-0000-0000-000000000000/$(cat /proc/sys/kernel/random/uuid)/" "$PHP_EXT_DIR/relay.so"


### PR DESCRIPTION
Used `hiredis` and `libck` binary packages from OpenSUSE