### PR TITLE
Replace relay-pkg.so with relay.so in Dockerfile for Amazon Linux 2

### DIFF
--- a/docker/al2.Dockerfile
+++ b/docker/al2.Dockerfile
@@ -4,6 +4,7 @@ RUN yum -y install \
   gcc \
   make \
   tar \
+  gzip \
   yum-utils
 
 RUN yum remove php*
@@ -11,11 +12,11 @@ RUN amazon-linux-extras enable php8.0
 
 RUN yum install -y \
   php-cli \
-  php-fpm \
   php-pear \
   php-devel \
   openssl11 \
-  libzstd-devel
+  libzstd \
+  lz4
 
 RUN pecl config-set php_ini /etc/php.ini
 
@@ -29,6 +30,10 @@ RUN pecl install igbinary && \
 
 ARG RELAY=v0.6.6
 
+RUN yum install -y \
+  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.1.x86_64.rpm \
+  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.7.x86_64.rpm
+
 # Download Relay
 RUN ARCH=$(uname -m | sed 's/_/-/') \
   PHP=$(php -r 'echo substr(PHP_VERSION, 0, 3);') \
@@ -37,7 +42,7 @@ RUN ARCH=$(uname -m | sed 's/_/-/') \
 # Copy relay.{so,ini}
 RUN ARCH=$(uname -m | sed 's/_/-/') \
   && cp "/tmp/relay-$RELAY-php8.0-centos7-$ARCH/relay.ini" $(php-config --ini-dir)/50-relay.ini \
-  && cp "/tmp/relay-$RELAY-php8.0-centos7-$ARCH/relay-pkg.so" $(php-config --extension-dir)/relay.so
+  && cp "/tmp/relay-$RELAY-php8.0-centos7-$ARCH/relay.so" $(php-config --extension-dir)/relay.so
 
 # Inject UUID
 RUN sed -i "s/00000000-0000-0000-0000-000000000000/$(cat /proc/sys/kernel/random/uuid)/" $(php-config --extension-dir)/relay.so

--- a/docker/al2.Dockerfile
+++ b/docker/al2.Dockerfile
@@ -22,8 +22,9 @@ RUN pecl config-set php_ini /etc/php.ini
 RUN yum install -y \
   libzstd \
   lz4 \
-  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.1.x86_64.rpm \
-  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.7.x86_64.rpm
+  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.7.x86_64.rpm \
+  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.1.x86_64.rpm
+  
 
 # Relay requires the `msgpack` extension
 RUN pecl install msgpack && \

--- a/docker/al2.Dockerfile
+++ b/docker/al2.Dockerfile
@@ -24,7 +24,6 @@ RUN yum install -y \
   lz4 \
   https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.7.x86_64.rpm \
   https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.1.x86_64.rpm
-  
 
 # Relay requires the `msgpack` extension
 RUN pecl install msgpack && \

--- a/docker/al2.Dockerfile
+++ b/docker/al2.Dockerfile
@@ -14,11 +14,16 @@ RUN yum install -y \
   php-cli \
   php-pear \
   php-devel \
-  openssl11 \
-  libzstd \
-  lz4
+  openssl11
 
 RUN pecl config-set php_ini /etc/php.ini
+
+# Install Relay dependencies
+RUN yum install -y \
+  libzstd \
+  lz4 \
+  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.1.x86_64.rpm \
+  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.7.x86_64.rpm
 
 # Relay requires the `msgpack` extension
 RUN pecl install msgpack && \
@@ -29,10 +34,6 @@ RUN pecl install igbinary && \
   echo "extension = igbinary.so" > $(php-config --ini-dir)/40-igbinary.ini
 
 ARG RELAY=v0.6.6
-
-RUN yum install -y \
-  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.1.x86_64.rpm \
-  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.7.x86_64.rpm
 
 # Download Relay
 RUN ARCH=$(uname -m | sed 's/_/-/') \


### PR DESCRIPTION
Older packages for OpenSUSE are compatible with Amazon Linux