### PR TITLE
Replace relay-pkg.so with relay.so in Dockerfile for CentOS 7

### DIFF
--- a/docker/centos7/centos7.Dockerfile
+++ b/docker/centos7/centos7.Dockerfile
@@ -18,16 +18,16 @@ ARG RELAY=v0.6.6
 
 # Install Relay dependencies
 RUN yum install -y \
-  openssl11 libzstd lz4
+  openssl11 \
+  libzstd \
+  lz4 \
+  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.7.x86_64.rpm \
+  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.1.x86_64.rpm
 
 # Relay requires the `msgpack` and `igbinary` extension
 RUN yum install -y \
   php80-php-igbinary \
   php80-php-msgpack
-
-RUN yum install -y \
-  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.1.x86_64.rpm \
-  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.7.x86_64.rpm
 
 # Download Relay
 RUN PLATFORM=$(uname -m | sed 's/_/-/') \

--- a/docker/centos7/centos7.Dockerfile
+++ b/docker/centos7/centos7.Dockerfile
@@ -1,8 +1,6 @@
 FROM --platform=linux/amd64 centos:7
 
-RUN yum install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 RUN yum install -y "https://rpms.remirepo.net/enterprise/remi-release-7.rpm"
-RUN yum install -y yum-utils
 
 RUN yum-config-manager --disable 'remi-php*' \
   yum-config-manager --enable remi-safe
@@ -27,6 +25,10 @@ RUN yum install -y \
   php80-php-igbinary \
   php80-php-msgpack
 
+RUN yum install -y \
+  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.1.x86_64.rpm \
+  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.7.x86_64.rpm
+
 # Download Relay
 RUN PLATFORM=$(uname -m | sed 's/_/-/') \
   && curl -L "https://builds.r2.relay.so/$RELAY/relay-$RELAY-php8.0-centos7-$PLATFORM.tar.gz" | tar xz -C /tmp
@@ -34,7 +36,7 @@ RUN PLATFORM=$(uname -m | sed 's/_/-/') \
 # Copy relay.{so,ini}
 RUN PLATFORM=$(uname -m | sed 's/_/-/') \
   && cp "/tmp/relay-$RELAY-php8.0-centos7-$PLATFORM/relay.ini" "$PHP_INI_DIR/50-relay.ini" \
-  && cp "/tmp/relay-$RELAY-php8.0-centos7-$PLATFORM/relay-pkg.so" "$PHP_EXT_DIR/relay.so"
+  && cp "/tmp/relay-$RELAY-php8.0-centos7-$PLATFORM/relay.so" "$PHP_EXT_DIR/relay.so"
 
 # Inject UUID
 RUN sed -i "s/00000000-0000-0000-0000-000000000000/$(cat /proc/sys/kernel/random/uuid)/" "$PHP_EXT_DIR/relay.so"


### PR DESCRIPTION
Older packages for OpenSUSE are compatible with CentOS 7