### PR TITLE
We don't want to construct a new object here

### DIFF
--- a/src/Psr/SimpleCache/RelayCache.php
+++ b/src/Psr/SimpleCache/RelayCache.php
@@ -31,7 +31,7 @@ class RelayCache implements CacheInterface
      */
     public function __construct(Relay $relay)
     {
-        $this->relay = new $relay;
+        $this->relay = $relay;
     }
 
     /**


### PR DESCRIPTION
We just want to receive the underlying `\Relay\Relay` object and use it in the cache, not create a new one.

Fixes #130