### PR TITLE
Fix EOL builds.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
           - centos8/centos8
           - centos8/rocky8
           - el9/el9
-          - debian/debian10
+          - debian/debian11
           - ubuntu/ubuntu20
           - mint21
           - litespeed

--- a/docker/centos7/centos7-yum-single.Dockerfile
+++ b/docker/centos7/centos7-yum-single.Dockerfile
@@ -1,5 +1,11 @@
 FROM --platform=linux/amd64 centos:7
 
+# It's dead, Jim
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+RUN yum update -y
+
 RUN yum install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 RUN yum install -y "https://rpms.remirepo.net/enterprise/remi-release-7.rpm"
 RUN yum install -y yum-utils

--- a/docker/centos7/centos7-yum.Dockerfile
+++ b/docker/centos7/centos7-yum.Dockerfile
@@ -1,5 +1,11 @@
 FROM --platform=linux/amd64 centos:7
 
+# It's dead, Jim
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+RUN yum update -y
+
 RUN yum install -y "https://rpms.remirepo.net/enterprise/remi-release-7.rpm"
 
 RUN yum install -y \

--- a/docker/centos7/centos7.Dockerfile
+++ b/docker/centos7/centos7.Dockerfile
@@ -1,5 +1,11 @@
 FROM --platform=linux/amd64 centos:7
 
+# It's dead, Jim
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+RUN yum -y update
+
 RUN yum install -y "https://rpms.remirepo.net/enterprise/remi-release-7.rpm"
 
 RUN yum-config-manager --disable 'remi-php*' \

--- a/docker/centos7/centos7.Dockerfile
+++ b/docker/centos7/centos7.Dockerfile
@@ -27,8 +27,8 @@ RUN yum install -y \
   openssl11 \
   libzstd \
   lz4 \
-  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.11.x86_64.rpm \
-  https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.6.x86_64.rpm
+  https://rpmfind.net/linux/opensuse/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.11.x86_64.rpm \
+  http://rpmfind.net/linux/opensuse/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.6.x86_64.rpm
 
 # Relay requires the `msgpack` and `igbinary` extension
 RUN yum install -y \
@@ -46,3 +46,6 @@ RUN PLATFORM=$(uname -m | sed 's/_/-/') \
 
 # Inject UUID
 RUN sed -i "s/00000000-0000-0000-0000-000000000000/$(cat /proc/sys/kernel/random/uuid)/" "$PHP_EXT_DIR/relay.so"
+
+# Ensure relay was installed properly.
+RUN php -m | grep relay

--- a/docker/centos7/centos7.Dockerfile
+++ b/docker/centos7/centos7.Dockerfile
@@ -28,7 +28,7 @@ RUN yum install -y \
   libzstd \
   lz4 \
   https://rpmfind.net/linux/opensuse/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.11.x86_64.rpm \
-  http://rpmfind.net/linux/opensuse/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.6.x86_64.rpm
+  https://rpmfind.net/linux/opensuse/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.6.x86_64.rpm
 
 # Relay requires the `msgpack` and `igbinary` extension
 RUN yum install -y \

--- a/docker/centos7/centos7.Dockerfile
+++ b/docker/centos7/centos7.Dockerfile
@@ -48,4 +48,4 @@ RUN PLATFORM=$(uname -m | sed 's/_/-/') \
 RUN sed -i "s/00000000-0000-0000-0000-000000000000/$(cat /proc/sys/kernel/random/uuid)/" "$PHP_EXT_DIR/relay.so"
 
 # Ensure relay was installed properly.
-RUN php -m | grep relay
+RUN php --ri relay

--- a/docker/debian/README.md
+++ b/docker/debian/README.md
@@ -15,7 +15,7 @@ $ php --ri relay
 ## Debian (manual)
 
 ```bash
-docker build --pull --tag relay-debian --file debian10.Dockerfile .
+docker build --pull --tag relay-debian --file debian11.Dockerfile .
 docker run -it relay-debian bash
 $ php --ri relay
 ```

--- a/docker/debian/debian11.Dockerfile
+++ b/docker/debian/debian11.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10.10
+FROM debian:11
 
 RUN apt-get update
 
@@ -40,3 +40,7 @@ RUN PLATFORM=$(uname -m | sed 's/_/-/') \
 
 # Inject UUID
 RUN sed -i "s/00000000-0000-0000-0000-000000000000/$(cat /proc/sys/kernel/random/uuid)/" $(php-config --extension-dir)/relay.so
+
+
+# Ensure Relay is correctly installed
+RUN php --ri relay

--- a/docker/debian/debian11.Dockerfile
+++ b/docker/debian/debian11.Dockerfile
@@ -41,6 +41,5 @@ RUN PLATFORM=$(uname -m | sed 's/_/-/') \
 # Inject UUID
 RUN sed -i "s/00000000-0000-0000-0000-000000000000/$(cat /proc/sys/kernel/random/uuid)/" $(php-config --extension-dir)/relay.so
 
-
 # Ensure Relay is correctly installed
 RUN php --ri relay


### PR DESCRIPTION
* Fix CentOS 7 by switching to the "vault" mirrors.
* Drop support for debian 10.  In order to support that distro we would have to build PHP manually.