### PR TITLE
Run benchmarks against APCu and Relay\Table

### DIFF
--- a/benchmarks/Cases/BenchmarkInMemoryGet.php
+++ b/benchmarks/Cases/BenchmarkInMemoryGet.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Cases;
+
+use CacheWerk\Relay\Benchmarks\Support\BenchmarkInMemoryCommand;
+
+class BenchmarkInMemoryGet extends BenchmarkInMemoryCommand
+{
+    public static function flags(): int
+    {
+        return self::STRING | self::READ | self::DEFAULT;
+    }
+
+    public function command(): string
+    {
+        return str_replace('inmemory', '', parent::command());
+    }
+
+    public function seed(): void
+    {
+        $clients = $this->clients();
+
+        foreach ($this->loadJsonFile('meteorites.json') as $item) {
+            foreach ($clients as $client) {
+                $client->set((string) $item['id'], $item);
+            }
+            $this->keys[] = $item['id'];
+        }
+    }
+}

--- a/benchmarks/Cases/BenchmarkInMemoryGet.php
+++ b/benchmarks/Cases/BenchmarkInMemoryGet.php
@@ -8,7 +8,7 @@ class BenchmarkInMemoryGet extends BenchmarkInMemoryCommand
 {
     public static function flags(): int
     {
-        return self::STRING | self::READ | self::DEFAULT;
+        return self::STRING | self::READ;
     }
 
     public function command(): string

--- a/benchmarks/Cases/BenchmarkInMemoryGet.php
+++ b/benchmarks/Cases/BenchmarkInMemoryGet.php
@@ -8,12 +8,12 @@ class BenchmarkInMemoryGet extends BenchmarkInMemoryCommand
 {
     public static function flags(): int
     {
-        return self::STRING | self::READ;
+        return self::STRING | self::READ | self::DEFAULT;
     }
 
     public function command(): string
     {
-        return str_replace('inmemory', '', parent::command());
+        return 'get';
     }
 
     public function seed(): void
@@ -21,10 +21,13 @@ class BenchmarkInMemoryGet extends BenchmarkInMemoryCommand
         $clients = $this->clients();
 
         foreach ($this->loadJsonFile('meteorites.json') as $item) {
+            $key = (string) $item['id'];
+
             foreach ($clients as $client) {
-                $client->set((string) $item['id'], $item);
+                $client->set($key, $item);
             }
-            $this->keys[] = $item['id'];
+
+            $this->keys[] = $key;
         }
     }
 }

--- a/benchmarks/Cases/BenchmarkInMemoryGet.php
+++ b/benchmarks/Cases/BenchmarkInMemoryGet.php
@@ -8,7 +8,7 @@ class BenchmarkInMemoryGet extends BenchmarkInMemoryCommand
 {
     public static function flags(): int
     {
-        return self::STRING | self::READ | self::DEFAULT;
+        return self::STRING | self::MEMORY | self::DEFAULT;
     }
 
     public function command(): string

--- a/benchmarks/Cases/BenchmarkZincrby.php
+++ b/benchmarks/Cases/BenchmarkZincrby.php
@@ -13,7 +13,7 @@ class BenchmarkZINCRBY extends Benchmark
 
     public static function flags(): int
     {
-        return self::ZSET | self::READ;
+        return self::ZSET | self::WRITE;
     }
 
     public function setUp(): void

--- a/benchmarks/Support/ApcuClient.php
+++ b/benchmarks/Support/ApcuClient.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Support;
+
+class ApcuClient implements InMemoryClient
+{
+    public function clear(): bool
+    {
+        return apcu_clear_cache();
+    }
+
+    public function get(string $key): mixed
+    {
+        return apcu_fetch($key);
+    }
+
+    public function set(string $key, mixed $value): bool
+    {
+        return (bool) apcu_store($key, $value);
+    }
+}

--- a/benchmarks/Support/Benchmark.php
+++ b/benchmarks/Support/Benchmark.php
@@ -224,10 +224,7 @@ abstract class Benchmark
     public function refreshClients(): void
     {
         $this->predis = $this->createPredis();
-
-        if (extension_loaded('redis')) {
-            $this->phpredis = $this->createPhpRedis();
-        }
+        $this->phpredis = $this->createPhpRedis();
     }
 
     /**
@@ -326,9 +323,19 @@ abstract class Benchmark
 
         return new class
         {
-            public function get($key)
+            public function clear(): bool
+            {
+                return apcu_clear_cache();
+            }
+
+            public function get(string $key): mixed
             {
                 return apcu_fetch($key);
+            }
+
+            public function set(string $key, $value): bool
+            {
+                return apcu_store($key, $value);
             }
         };
     }

--- a/benchmarks/Support/Benchmark.php
+++ b/benchmarks/Support/Benchmark.php
@@ -51,9 +51,9 @@ abstract class Benchmark
 
     protected Predis $predis;
 
-    protected Table $table;
-
     protected ?PhpRedis $phpredis;
+
+    protected object $table;
 
     protected ?object $apcu;
 
@@ -225,6 +225,8 @@ abstract class Benchmark
     {
         $this->predis = $this->createPredis();
         $this->phpredis = $this->createPhpRedis();
+        $this->table = $this->createRelayTable();
+        $this->apcu = $this->createAPCu();
     }
 
     /**
@@ -310,9 +312,26 @@ abstract class Benchmark
         ]);
     }
 
-    public function createRelayTable(): Table
+    public function createRelayTable(): object
     {
-        return new Table;
+        return new class
+        {
+            public function clear(): bool
+            {
+                return Table::clearAll();
+            }
+
+            public function get(string $key): mixed
+            {
+                return Table::get($key);
+            }
+
+            public function set(string $key, $value): bool
+            {
+                return Table::set($key, $value);
+            }
+        };
+
     }
 
     protected function createAPCu(): ?object

--- a/benchmarks/Support/Benchmark.php
+++ b/benchmarks/Support/Benchmark.php
@@ -33,7 +33,9 @@ abstract class Benchmark
 
     const DEFAULT = 0x400;
 
-    const ALL = self::READ | self::WRITE | self::ALL_TYPES;
+    const MEMORY = 0x800;
+
+    const ALL = self::READ | self::WRITE | self::MEMORY | self::ALL_TYPES;
 
     protected string $host;
 

--- a/benchmarks/Support/Benchmark.php
+++ b/benchmarks/Support/Benchmark.php
@@ -5,7 +5,6 @@ namespace CacheWerk\Relay\Benchmarks\Support;
 use Exception;
 use Redis as PhpRedis;
 use Relay\Relay;
-use Relay\Table;
 use Predis\Client as Predis;
 
 abstract class Benchmark
@@ -51,11 +50,7 @@ abstract class Benchmark
 
     protected Predis $predis;
 
-    protected ?PhpRedis $phpredis;
-
-    protected object $table;
-
-    protected ?object $apcu;
+    protected PhpRedis $phpredis;
 
     /**
      * @param  string  $host
@@ -209,9 +204,10 @@ abstract class Benchmark
         $this->predis = $this->createPredis();
         $this->relay = $this->createRelay();
         $this->relayNoCache = $this->createRelayNoCache();
-        $this->phpredis = $this->createPhpRedis();
-        $this->table = $this->createRelayTable();
-        $this->apcu = $this->createAPCu();
+
+        if (extension_loaded('redis')) {
+            $this->phpredis = $this->createPhpRedis();
+        }
     }
 
     /**
@@ -224,9 +220,10 @@ abstract class Benchmark
     public function refreshClients(): void
     {
         $this->predis = $this->createPredis();
-        $this->phpredis = $this->createPhpRedis();
-        $this->table = $this->createRelayTable();
-        $this->apcu = $this->createAPCu();
+
+        if (extension_loaded('redis')) {
+            $this->phpredis = $this->createPhpRedis();
+        }
     }
 
     /**
@@ -267,12 +264,8 @@ abstract class Benchmark
         return $relay;
     }
 
-    protected function createPhpRedis(): ?PhpRedis
+    protected function createPhpRedis(): PhpRedis
     {
-        if (! extension_loaded('redis')) {
-            return null;
-        }
-
         $phpredis = new PhpRedis;
         $phpredis->connect($this->host, $this->port, 0.5, '', 0, 0.5);
         $phpredis->setOption(PhpRedis::OPT_MAX_RETRIES, 0);
@@ -312,51 +305,21 @@ abstract class Benchmark
         ]);
     }
 
-    public function createRelayTable(): object
+    /**
+     * The client subjects this benchmark runs against, each
+     * matching a `benchmark{$subject}()` method.
+     *
+     * @return array<int, string>
+     */
+    protected function subjects(): array
     {
-        return new class
-        {
-            public function clear(): bool
-            {
-                return Table::clearAll();
-            }
+        if (! extension_loaded('redis')) {
+            Reporter::printWarning('Skipping PhpRedis runs, extension is not loaded');
 
-            public function get(string $key): mixed
-            {
-                return Table::get($key);
-            }
-
-            public function set(string $key, $value): bool
-            {
-                return Table::set($key, $value);
-            }
-        };
-
-    }
-
-    protected function createAPCu(): ?object
-    {
-        if (! extension_loaded('apcu')) {
-            return null;
+            return ['Predis', 'RelayNoCache', 'Relay'];
         }
 
-        return new class
-        {
-            public function clear(): bool
-            {
-                return apcu_clear_cache();
-            }
-
-            public function get(string $key): mixed
-            {
-                return apcu_fetch($key);
-            }
-
-            public function set(string $key, $value): bool
-            {
-                return apcu_store($key, $value);
-            }
-        };
+        return ['Predis', 'PhpRedis', 'RelayNoCache', 'Relay'];
     }
 
     /**
@@ -364,40 +327,15 @@ abstract class Benchmark
      */
     public function getBenchmarkMethods(string $filter): array
     {
-        $exclude = [];
+        $methods = [];
 
-        if (! extension_loaded('redis')) {
-            $exclude[] = 'PhpRedis';
-
-            Reporter::printWarning('Skipping PhpRedis runs, extension is not loaded');
-        }
-
-        if (! extension_loaded('apcu')) {
-            $exclude[] = 'APCu';
-
-            Reporter::printWarning('Skipping APCu runs, extension is not loaded');
-        }
-
-        return array_filter(
-            get_class_methods($this),
-            function ($method) use ($exclude, $filter) {
-                if (! str_starts_with($method, 'benchmark')) {
-                    return false;
-                }
-
-                $method = substr($method, strlen('benchmark'));
-
-                if (in_array($method, $exclude, true)) {
-                    return false;
-                }
-
-                if ($filter && ! preg_match("/{$filter}/i", strtolower($method))) {
-                    return false;
-                }
-
-                return true;
+        foreach ($this->subjects() as $subject) {
+            if (! $filter || preg_match("/{$filter}/i", strtolower($subject))) {
+                $methods[] = "benchmark{$subject}";
             }
-        );
+        }
+
+        return $methods;
     }
 
     public function benchmarkPredis(): int
@@ -418,15 +356,5 @@ abstract class Benchmark
     public function benchmarkRelay(): int
     {
         return $this->runBenchmark($this->relay);
-    }
-
-    public function benchmarkRelayTable(): int
-    {
-        return $this->runBenchmark($this->table);
-    }
-
-    public function benchmarkAPCu(): int
-    {
-        return $this->runBenchmark($this->apcu);
     }
 }

--- a/benchmarks/Support/BenchmarkInMemoryCommand.php
+++ b/benchmarks/Support/BenchmarkInMemoryCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Support;
+
+abstract class BenchmarkInMemoryCommand extends Benchmark
+{
+    /**
+     * @var array<int, string>
+     */
+    protected array $keys;
+
+    public function setUp(): void
+    {
+        $this->setUpClients();
+        $this->flush();
+
+        if (method_exists($this, 'seed')) {
+            $this->seed();
+        }
+    }
+
+    protected function clients(): array
+    {
+        return array_filter([
+            $this->table,
+            $this->apcu,
+        ]);
+    }
+
+    protected function flush(): void
+    {
+        foreach ($this->clients() as $client) {
+            $client->clear();
+        }
+    }
+
+    /**
+     * @param  mixed  $client
+     */
+    protected function runBenchmark($client): int
+    {
+        $cmd = $this->command();
+
+        foreach ($this->keys as $key) {
+            $client->{$cmd}($key);
+        }
+
+        return count($this->keys);
+    }
+}

--- a/benchmarks/Support/BenchmarkInMemoryCommand.php
+++ b/benchmarks/Support/BenchmarkInMemoryCommand.php
@@ -2,12 +2,13 @@
 
 namespace CacheWerk\Relay\Benchmarks\Support;
 
-abstract class BenchmarkInMemoryCommand extends Benchmark
+use Relay\Table;
+
+abstract class BenchmarkInMemoryCommand extends BenchmarkKeyCommand
 {
-    /**
-     * @var array<int, string>
-     */
-    protected array $keys;
+    protected RelayTableClient $table;
+
+    protected ApcuClient $apcu;
 
     public function setUp(): void
     {
@@ -19,12 +20,54 @@ abstract class BenchmarkInMemoryCommand extends Benchmark
         }
     }
 
+    public function setUpClients(): void
+    {
+        parent::setUpClients();
+
+        if (class_exists(Table::class)) {
+            $this->table = new RelayTableClient;
+        }
+
+        if (extension_loaded('apcu')) {
+            $this->apcu = new ApcuClient;
+        }
+    }
+
+    protected function subjects(): array
+    {
+        $subjects = [];
+
+        if (class_exists(Table::class)) {
+            $subjects[] = 'RelayTable';
+        } else {
+            Reporter::printWarning('Skipping Relay\Table runs, class is not available');
+        }
+
+        if (extension_loaded('apcu')) {
+            $subjects[] = 'APCu';
+        } else {
+            Reporter::printWarning('Skipping APCu runs, extension is not loaded');
+        }
+
+        return $subjects;
+    }
+
+    /**
+     * @return array<int, InMemoryClient>
+     */
     protected function clients(): array
     {
-        return array_filter([
-            $this->table,
-            $this->apcu,
-        ]);
+        $clients = [];
+
+        if (isset($this->table)) {
+            $clients[] = $this->table;
+        }
+
+        if (isset($this->apcu)) {
+            $clients[] = $this->apcu;
+        }
+
+        return $clients;
     }
 
     protected function flush(): void
@@ -34,17 +77,13 @@ abstract class BenchmarkInMemoryCommand extends Benchmark
         }
     }
 
-    /**
-     * @param  mixed  $client
-     */
-    protected function runBenchmark($client): int
+    public function benchmarkRelayTable(): int
     {
-        $cmd = $this->command();
+        return $this->runBenchmark($this->table);
+    }
 
-        foreach ($this->keys as $key) {
-            $client->{$cmd}($key);
-        }
-
-        return count($this->keys);
+    public function benchmarkAPCu(): int
+    {
+        return $this->runBenchmark($this->apcu);
     }
 }

--- a/benchmarks/Support/BenchmarkKeyCommand.php
+++ b/benchmarks/Support/BenchmarkKeyCommand.php
@@ -24,7 +24,7 @@ abstract class BenchmarkKeyCommand extends Benchmark
     }
 
     /**
-     * @param  Relay|PhpRedis|Predis  $client
+     * @param  Relay|PhpRedis|Predis|InMemoryClient  $client
      */
     protected function runBenchmark($client): int
     {

--- a/benchmarks/Support/InMemoryClient.php
+++ b/benchmarks/Support/InMemoryClient.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Support;
+
+interface InMemoryClient
+{
+    public function clear(): bool;
+
+    public function get(string $key): mixed;
+
+    public function set(string $key, mixed $value): bool;
+}

--- a/benchmarks/Support/RelayTableClient.php
+++ b/benchmarks/Support/RelayTableClient.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Support;
+
+use Relay\Table;
+
+class RelayTableClient implements InMemoryClient
+{
+    public function clear(): bool
+    {
+        return Table::clearAll();
+    }
+
+    public function get(string $key): mixed
+    {
+        return Table::get($key);
+    }
+
+    public function set(string $key, mixed $value): bool
+    {
+        return Table::set($key, $value);
+    }
+}

--- a/benchmarks/Support/helpers.php
+++ b/benchmarks/Support/helpers.php
@@ -21,7 +21,7 @@ function printUsage(string $script): void
                 --warmup       Specifies how many warm up runs to execute. Defaults to 1.
                 --filter       A regex, or comma-separated list, to filter the benchmarked clients (e.g. 'relay,phpredis').
                 --key-type     A comma separated list of key types (string, set, hash, list, zset, hyperloglog).
-                --command-type A comma separated list of command types (default, read, write).
+                --command-type A comma separated list of command types (default, read, write, memory).
                 --all          Run every benchmark case, ignoring key/command type filters.
                 --json         Output results in JSON instead of a table.
             -v, --verbose      Enables verbose output.
@@ -76,10 +76,12 @@ function getCommandTypes(array $opt, string $key, array $default): int
             $result |= Support\Benchmark::READ;
         } elseif (! strcasecmp($type, 'write')) {
             $result |= Support\Benchmark::WRITE;
+        } elseif (! strcasecmp($type, 'memory')) {
+            $result |= Support\Benchmark::MEMORY;
         } elseif (! strcasecmp($type, 'default')) {
             $result |= Support\Benchmark::DEFAULT;
         } else {
-            fprintf(STDERR, "Error: Command type is only `read`, `write`, or `default`\n");
+            fprintf(STDERR, "Error: Command type is only `read`, `write`, `memory`, or `default`\n");
             exit(1);
         }
     }


### PR DESCRIPTION
See https://github.com/cachewerk/relay-core/issues/1202

```bash
php run --warmup 0 --workers 1 --filter RelayTable\|APCu BenchmarkGet.php 
Setting up on AMD Ryzen 7 4700U with Radeon Graphics (8 cores/8 threads x86_64)
Using PHP 8.3.27 (OPcache: Off, Xdebug: Off, New Relic: Off)
Connected to Redis (8.2.2) at tcp://127.0.0.1:6379


 GET  Executing 5 iterations (0 warmup) for 1.00s seconds

+------------+--------+---------+---------+--------+-------------+--------+--------+--------+
| Client     | Memory | Network | Workers | IOPS   | IOPS/Worker | rstdev | Change | Factor |
+------------+--------+---------+---------+--------+-------------+--------+--------+--------+
| APCu       | 1.41mb |    181b |       1 | 13.01M |      13.01M | ±0.28% |  0.00% |  1.00x |
| RelayTable | 1.41mb |    181b |       1 | 21.01M |      21.01M | ±1.80% | 61.49% |  1.61x |
+------------+--------+---------+---------+--------+-------------+--------+--------+--------+
```