### PR TITLE
Add FrankenPHP example

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,6 +41,7 @@ jobs:
           - mint21
           - sle15
           - php-cli
+          - frankenphp
 
     services:
       redis:

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,20 @@
 
 These Docker environments are concrete examples of Relay's [installation instruction](https://relay.so/docs/installation).
 
+## Versions / Nightly builds
+
+You may specify the Relay version/build for non-package (APT/YUM) Docker examples:
+
+```bash
+docker build --pull --tag relay-alpine --file alpine.Dockerfile --build-arg RELAY=v0.9.1 .
+```
+
+To install the nightly developments builds use the `dev` version:
+
+```bash
+docker build --pull --tag relay-alpine --file alpine.Dockerfile --build-arg RELAY=dev .
+```
+
 ## Amazon Linux 2
 
 ```bash
@@ -34,6 +48,38 @@ docker run -it relay-apache2 bash
 $ php --ri relay
 ```
 
+## Arch Linux
+
+```bash
+docker build --pull --tag relay-arch --file arch.Dockerfile .
+docker run -it relay-arch bash
+$ php --ri relay
+```
+
+## FrankenPHP
+
+```bash
+docker build --pull --tag relay-frankenphp --file frankenphp.Dockerfile --build-arg RELAY=dev .
+docker run -it relay-frankenphp bash
+$ php --ri relay
+```
+
+## Linux Mint 21
+
+```bash
+docker build --pull --tag relay-mint21 --file mint21.Dockerfile .
+docker run -it relay-mint21 bash
+$ php --ri relay
+```
+
+## SUSE Linux Enterprise 15
+
+```bash
+docker build --pull --tag relay-sle15 --file sle15.Dockerfile .
+docker run -it relay-sle15 bash
+$ php --ri relay
+```
+
 ## PHP Images
 
 This image uses `mlocati/php-extension-installer` to install the extension.
@@ -42,18 +88,4 @@ This image uses `mlocati/php-extension-installer` to install the extension.
 docker build --pull --tag relay-php-cli --file php-cli.Dockerfile .
 docker run -it relay-php-cli bash
 $ php --ri relay
-```
-
-## Versions / Nightly builds
-
-You may specify the Relay version/build for non-package (APT/YUM) Docker examples:
-
-```bash
-docker build --pull --tag relay-alpine --file alpine.Dockerfile --build-arg RELAY=v0.9.1 .
-```
-
-To install the nightly developments builds use the `dev` version:
-
-```bash
-docker build --pull --tag relay-alpine --file alpine.Dockerfile --build-arg RELAY=dev .
 ```

--- a/docker/frankenphp.Dockerfile
+++ b/docker/frankenphp.Dockerfile
@@ -1,0 +1,37 @@
+FROM dunglas/frankenphp:php8.5-trixie
+
+# Overlay upstream; bundled version does not support ZTS artifacts yet
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+
+# Install Relay dependencies
+RUN apt-get update && apt-get install -y \
+    libck0t64 \
+    libhiredis1.1.0 \
+    liblz4-1 \
+    libzstd1
+
+# Relay requires the `msgpack` and `igbinary` extension
+RUN install-php-extensions igbinary msgpack
+
+ARG RELAY=v0.21.0
+
+# Download and install Relay
+# RUN install-php-extensions "relay${RELAY:+-$RELAY}"
+
+# --- STOP ---
+# The one-liner above is what you should use. Our CI matrix needs to test
+# against `dev` builds and `install-php-extensions` not does support that.
+
+# Download Relay
+RUN ARCH=$(dpkg --print-architecture | sed 's/amd64/x86-64/; s/arm64/aarch64/') \
+  PHP=$(php -r 'echo substr(PHP_VERSION, 0, 3);') \
+  ARTIFACT="https://builds.r2.relay.so/$RELAY/relay-$RELAY-php$PHP-debian-$ARCH+libssl3.tar.gz" \
+  && curl -L $ARTIFACT | tar -xz --strip-components=1 -C /tmp
+
+# Copy relay.{so,ini}
+RUN cp "/tmp/relay.ini" "$(php-config --ini-dir)/50-relay.ini" \
+  && cp "/tmp/relay-zts.so" "$(php-config --extension-dir)/relay.so"
+
+# Inject UUID
+RUN UUID=$(cat /proc/sys/kernel/random/uuid) \
+  && sed -i "s/00000000-0000-0000-0000-000000000000/$UUID/" "$(php-config --extension-dir)/relay.so"


### PR DESCRIPTION
The builds will fail until v0.22.0 is released, until then `dev` builds now build with `--disable-zend-signals`.

Resolves #204.
Resolves #155.