### PR TITLE
Add Swoole\Table to in-memory benchmarks

### DIFF
--- a/benchmarks/Support/Benchmarks/InMemoryCommand.php
+++ b/benchmarks/Support/Benchmarks/InMemoryCommand.php
@@ -5,15 +5,19 @@ namespace CacheWerk\Relay\Benchmarks\Support\Benchmarks;
 use Exception;
 
 use Relay\Table;
+use Swoole\Table as SwooleTable;
 
 use CacheWerk\Relay\Benchmarks\Support\Reporter;
 use CacheWerk\Relay\Benchmarks\Support\Clients\ApcuClient;
 use CacheWerk\Relay\Benchmarks\Support\Clients\InMemoryClient;
 use CacheWerk\Relay\Benchmarks\Support\Clients\RelayTableClient;
+use CacheWerk\Relay\Benchmarks\Support\Clients\SwooleTableClient;
 
 abstract class InMemoryCommand extends KeyCommand
 {
     protected RelayTableClient $table;
+
+    protected SwooleTableClient $swooleTable;
 
     protected ApcuClient $apcu;
 
@@ -57,6 +61,10 @@ abstract class InMemoryCommand extends KeyCommand
             $this->table = new RelayTableClient;
         }
 
+        if (class_exists(SwooleTable::class)) {
+            $this->swooleTable = new SwooleTableClient;
+        }
+
         if (extension_loaded('apcu') && apcu_enabled()) {
             $this->apcu = new ApcuClient;
         }
@@ -70,6 +78,12 @@ abstract class InMemoryCommand extends KeyCommand
             $subjects[] = 'RelayTable';
         } else {
             Reporter::printWarning('Skipping Relay\Table runs, class is not available');
+        }
+
+        if (class_exists(SwooleTable::class)) {
+            $subjects[] = 'SwooleTable';
+        } else {
+            Reporter::printWarning('Skipping Swoole\Table runs, extension is not loaded');
         }
 
         if (! extension_loaded('apcu')) {
@@ -94,6 +108,10 @@ abstract class InMemoryCommand extends KeyCommand
             $clients[] = $this->table;
         }
 
+        if (isset($this->swooleTable)) {
+            $clients[] = $this->swooleTable;
+        }
+
         if (isset($this->apcu)) {
             $clients[] = $this->apcu;
         }
@@ -111,6 +129,11 @@ abstract class InMemoryCommand extends KeyCommand
     public function benchmarkRelayTable(): int
     {
         return $this->runBenchmark($this->table);
+    }
+
+    public function benchmarkSwooleTable(): int
+    {
+        return $this->runBenchmark($this->swooleTable);
     }
 
     public function benchmarkAPCu(): int

--- a/benchmarks/Support/Clients/SwooleTableClient.php
+++ b/benchmarks/Support/Clients/SwooleTableClient.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace CacheWerk\Relay\Benchmarks\Support\Clients;
+
+use Swoole\Table;
+
+/**
+ * Swoole tables only hold fixed-size scalar columns, so values are
+ * serialized into a single string column — comparable to APCu and
+ * Relay\Table, which serialize internally.
+ */
+class SwooleTableClient implements InMemoryClient
+{
+    protected Table $table;
+
+    protected int $rows;
+
+    protected int $valueSize;
+
+    public function __construct(int $rows = 2048, int $valueSize = 1024)
+    {
+        $this->rows = $rows;
+        $this->valueSize = $valueSize;
+
+        $this->createTable();
+    }
+
+    /**
+     * Swoole tables cannot be flushed, drop the shared
+     * memory block and allocate a fresh one instead.
+     */
+    public function clear(): bool
+    {
+        $this->table->destroy();
+
+        return $this->createTable();
+    }
+
+    public function get(string $key): mixed
+    {
+        $value = $this->table->get($key, 'value');
+
+        return is_string($value) ? unserialize($value) : false;
+    }
+
+    public function set(string $key, mixed $value): bool
+    {
+        return $this->table->set($key, ['value' => serialize($value)]);
+    }
+
+    protected function createTable(): bool
+    {
+        $this->table = new Table($this->rows);
+        $this->table->column('value', Table::TYPE_STRING, $this->valueSize);
+
+        return $this->table->create();
+    }
+}


### PR DESCRIPTION
Adds `Swoole\Table` as a third subject to the in-memory `Table` benchmark, alongside `Relay\Table` and APCu.

- `SwooleTableClient` serializes values into a single fixed-size string column, since Swoole tables only hold scalar columns — comparable to APCu and `Relay\Table`, which serialize internally. `clear()` destroys and reallocates the shared memory block, as Swoole tables cannot be flushed.
- The subject registers only when `Swoole\Table` exists and prints the usual skip warning otherwise, matching the existing guards.
- No new dependencies: PHPStan resolves `Swoole\Table` from its bundled phpstorm-stubs, so level 9 passes without the extension.

Works with both Swoole and Open Swoole (≥ v22 ships `Swoole\*` compat aliases).

```
+-------------+--------+---------+---------+--------+-------------+--------+--------+--------+
| Client      | Memory | Network | Workers | IOPS   | IOPS/Worker | rstdev | Change | Factor |
+-------------+--------+---------+---------+--------+-------------+--------+--------+--------+
| APCu        | 3.84mb |    16kb |       6 |  5.00M |     833.54K | ±0.05% |  0.00% |  1.00x |
| SwooleTable | 3.84mb |    16kb |       6 |  9.42M |       1.57M | ±0.14% | 88.44% |  1.88x |
| RelayTable  | 3.82mb |    16kb |       6 | 12.31M |       2.05M | ±0.24% |   146% |  2.46x |
+-------------+--------+---------+---------+--------+-------------+--------+--------+--------+
```

PHP 8.5.7, Open Swoole 26.2.0, Apple M4 Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)