### PR TITLE
Mark igbinary/msgpack as optional in Docker build comments

### DIFF
--- a/docker/al2.Dockerfile
+++ b/docker/al2.Dockerfile
@@ -25,11 +25,7 @@ RUN yum install -y \
   https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.11.x86_64.rpm \
   https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.6.x86_64.rpm
 
-# Install the `msgpack` extension for Relay's msgpack serializer (optional, resolved at runtime)
-RUN pecl install msgpack && \
-  echo "extension = msgpack.so" > $(php-config --ini-dir)/40-msgpack.ini
-
-# Install the `igbinary` extension for Relay's igbinary serializer (optional, resolved at runtime)
+# Install optional `igbinary` extension
 RUN pecl install igbinary && \
   echo "extension = igbinary.so" > $(php-config --ini-dir)/40-igbinary.ini
 

--- a/docker/al2.Dockerfile
+++ b/docker/al2.Dockerfile
@@ -25,11 +25,11 @@ RUN yum install -y \
   https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.11.x86_64.rpm \
   https://download.opensuse.org/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.6.x86_64.rpm
 
-# Relay requires the `msgpack` extension
+# Install the `msgpack` extension for Relay's msgpack serializer (optional, resolved at runtime)
 RUN pecl install msgpack && \
   echo "extension = msgpack.so" > $(php-config --ini-dir)/40-msgpack.ini
 
-# Relay requires the `igbinary` extension
+# Install the `igbinary` extension for Relay's igbinary serializer (optional, resolved at runtime)
 RUN pecl install igbinary && \
   echo "extension = igbinary.so" > $(php-config --ini-dir)/40-igbinary.ini
 

--- a/docker/al2023.Dockerfile
+++ b/docker/al2023.Dockerfile
@@ -6,11 +6,7 @@ RUN dnf install -y \
   php-devel \
   gzip
 
-# Install the `msgpack` extension for Relay's msgpack serializer (optional, resolved at runtime)
-RUN pecl install msgpack && \
-  echo "extension = msgpack.so" > $(php-config --ini-dir)/40-msgpack.ini
-
-# Install the `igbinary` extension for Relay's igbinary serializer (optional, resolved at runtime)
+# Install optional `igbinary` extension
 RUN pecl install igbinary && \
   echo "extension = igbinary.so" > $(php-config --ini-dir)/40-igbinary.ini
 

--- a/docker/al2023.Dockerfile
+++ b/docker/al2023.Dockerfile
@@ -6,11 +6,11 @@ RUN dnf install -y \
   php-devel \
   gzip
 
-# Relay requires the `msgpack` extension
+# Install the `msgpack` extension for Relay's msgpack serializer (optional, resolved at runtime)
 RUN pecl install msgpack && \
   echo "extension = msgpack.so" > $(php-config --ini-dir)/40-msgpack.ini
 
-# Relay requires the `igbinary` extension
+# Install the `igbinary` extension for Relay's igbinary serializer (optional, resolved at runtime)
 RUN pecl install igbinary && \
   echo "extension = igbinary.so" > $(php-config --ini-dir)/40-igbinary.ini
 

--- a/docker/arch.Dockerfile
+++ b/docker/arch.Dockerfile
@@ -17,11 +17,11 @@ RUN curl -L https://github.com/concurrencykit/ck/archive/refs/tags/0.7.2.tar.gz 
 RUN curl -L https://github.com/redis/hiredis/archive/refs/tags/v1.2.0.tar.gz | tar -xzC /tmp \
   && USE_SSL=1 make -C /tmp/hiredis-1.2.0 install
 
-# Relay requires the `msgpack` extension
+# Install the `msgpack` extension for Relay's msgpack serializer (optional, resolved at runtime)
 RUN pecl install msgpack \
   && echo "extension = msgpack.so" > $(php-config --ini-dir)/10-msgpack.ini
 
-# Relay requires the `igbinary` extension
+# Install the `igbinary` extension for Relay's igbinary serializer (optional, resolved at runtime)
 RUN pecl install igbinary \
   && echo "extension = igbinary.so" > $(php-config --ini-dir)/10-igbinary.ini
 

--- a/docker/arch.Dockerfile
+++ b/docker/arch.Dockerfile
@@ -17,11 +17,7 @@ RUN curl -L https://github.com/concurrencykit/ck/archive/refs/tags/0.7.2.tar.gz 
 RUN curl -L https://github.com/redis/hiredis/archive/refs/tags/v1.2.0.tar.gz | tar -xzC /tmp \
   && USE_SSL=1 make -C /tmp/hiredis-1.2.0 install
 
-# Install the `msgpack` extension for Relay's msgpack serializer (optional, resolved at runtime)
-RUN pecl install msgpack \
-  && echo "extension = msgpack.so" > $(php-config --ini-dir)/10-msgpack.ini
-
-# Install the `igbinary` extension for Relay's igbinary serializer (optional, resolved at runtime)
+# Install optional `igbinary` extension
 RUN pecl install igbinary \
   && echo "extension = igbinary.so" > $(php-config --ini-dir)/10-igbinary.ini
 

--- a/docker/centos7/centos7.Dockerfile
+++ b/docker/centos7/centos7.Dockerfile
@@ -30,10 +30,8 @@ RUN yum install -y \
   https://rpmfind.net/linux/opensuse/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.11.x86_64.rpm \
   https://rpmfind.net/linux/opensuse/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.6.x86_64.rpm
 
-# Install the `msgpack` and `igbinary` extensions for Relay's serializers (optional, resolved at runtime)
-RUN yum install -y \
-  php80-php-igbinary \
-  php80-php-msgpack
+# Install optional extensions
+RUN yum install -y php80-php-igbinary
 
 # Download Relay
 RUN PLATFORM=$(uname -m | sed 's/_/-/') \

--- a/docker/centos7/centos7.Dockerfile
+++ b/docker/centos7/centos7.Dockerfile
@@ -30,7 +30,7 @@ RUN yum install -y \
   https://rpmfind.net/linux/opensuse/distribution/leap/15.5/repo/oss/x86_64/libck0-0.7.1-bp155.2.11.x86_64.rpm \
   https://rpmfind.net/linux/opensuse/distribution/leap/15.5/repo/oss/x86_64/libhiredis1_1_0-1.1.0-bp155.1.6.x86_64.rpm
 
-# Relay requires the `msgpack` and `igbinary` extension
+# Install the `msgpack` and `igbinary` extensions for Relay's serializers (optional, resolved at runtime)
 RUN yum install -y \
   php80-php-igbinary \
   php80-php-msgpack

--- a/docker/centos8/centos8.Dockerfile
+++ b/docker/centos8/centos8.Dockerfile
@@ -25,7 +25,7 @@ RUN yum install -y --nogpgcheck \
   libhiredis1_1_0 \
   libck0
 
-# Relay requires the `msgpack` and `igbinary` extension
+# Install the `msgpack` and `igbinary` extensions for Relay's serializers (optional, resolved at runtime)
 RUN yum install -y \
   php80-php-igbinary \
   php80-php-msgpack

--- a/docker/centos8/centos8.Dockerfile
+++ b/docker/centos8/centos8.Dockerfile
@@ -25,10 +25,8 @@ RUN yum install -y --nogpgcheck \
   libhiredis1_1_0 \
   libck0
 
-# Install the `msgpack` and `igbinary` extensions for Relay's serializers (optional, resolved at runtime)
-RUN yum install -y \
-  php80-php-igbinary \
-  php80-php-msgpack
+# Install optional extensions
+RUN yum install -y php80-php-igbinary
 
 # Download Relay
 RUN PLATFORM=$(uname -m | sed 's/_/-/') \

--- a/docker/centos8/rocky8.Dockerfile
+++ b/docker/centos8/rocky8.Dockerfile
@@ -21,7 +21,7 @@ RUN yum install -y --nogpgcheck \
   libhiredis1_1_0 \
   libck0
 
-# Relay requires the `msgpack` and `igbinary` extension
+# Install the `msgpack` and `igbinary` extensions for Relay's serializers (optional, resolved at runtime)
 RUN yum install -y \
   php80-php-igbinary \
   php80-php-msgpack

--- a/docker/centos8/rocky8.Dockerfile
+++ b/docker/centos8/rocky8.Dockerfile
@@ -21,10 +21,8 @@ RUN yum install -y --nogpgcheck \
   libhiredis1_1_0 \
   libck0
 
-# Install the `msgpack` and `igbinary` extensions for Relay's serializers (optional, resolved at runtime)
-RUN yum install -y \
-  php80-php-igbinary \
-  php80-php-msgpack
+# Install optional extensions
+RUN yum install -y php80-php-igbinary
 
 # Download Relay
 RUN PLATFORM=$(uname -m | sed 's/_/-/') \

--- a/docker/el9/el9.Dockerfile
+++ b/docker/el9/el9.Dockerfile
@@ -16,10 +16,8 @@ ENV PHP_EXT_DIR=/usr/lib64/php/modules
 
 ARG RELAY=v0.30.0
 
-# Install the `msgpack` and `igbinary` extensions for Relay's serializers (optional, resolved at runtime)
-RUN dnf -y install \
-  php-msgpack \
-  php-igbinary
+# Install optional extensions
+RUN dnf -y install php-igbinary
 
 # Install Relay dependencies
 RUN dnf install -y --nogpgcheck \

--- a/docker/el9/el9.Dockerfile
+++ b/docker/el9/el9.Dockerfile
@@ -16,7 +16,7 @@ ENV PHP_EXT_DIR=/usr/lib64/php/modules
 
 ARG RELAY=v0.30.0
 
-# Relay requires the `msgpack` and `igbinary` extension
+# Install the `msgpack` and `igbinary` extensions for Relay's serializers (optional, resolved at runtime)
 RUN dnf -y install \
   php-msgpack \
   php-igbinary

--- a/docker/frankenphp.Dockerfile
+++ b/docker/frankenphp.Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y \
     liblz4-1 \
     libzstd1
 
-# Install the `msgpack` and `igbinary` extensions for Relay's serializers (optional, resolved at runtime)
-RUN install-php-extensions igbinary msgpack
+# Install optional extensions
+RUN install-php-extensions igbinary
 
 ARG RELAY=v0.30.0
 

--- a/docker/frankenphp.Dockerfile
+++ b/docker/frankenphp.Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     liblz4-1 \
     libzstd1
 
-# Relay requires the `msgpack` and `igbinary` extension
+# Install the `msgpack` and `igbinary` extensions for Relay's serializers (optional, resolved at runtime)
 RUN install-php-extensions igbinary msgpack
 
 ARG RELAY=v0.30.0

--- a/docker/sle15.Dockerfile
+++ b/docker/sle15.Dockerfile
@@ -17,11 +17,7 @@ RUN zypper install -y \
   libhiredis1_1_0 \
   liblz4-1
 
-# Install the `msgpack` extension for Relay's msgpack serializer (optional, resolved at runtime)
-RUN pecl install msgpack && \
-  echo "extension = msgpack.so" > $(php-config --ini-dir)/msgpack.ini
-
-# Install the `igbinary` extension for Relay's igbinary serializer (optional, resolved at runtime)
+# Install optional `igbinary` extension
 RUN pecl install igbinary && \
   echo "extension = igbinary.so" > $(php-config --ini-dir)/igbinary.ini
 

--- a/docker/sle15.Dockerfile
+++ b/docker/sle15.Dockerfile
@@ -17,11 +17,11 @@ RUN zypper install -y \
   libhiredis1_1_0 \
   liblz4-1
 
-# Relay requires the `msgpack` extension
+# Install the `msgpack` extension for Relay's msgpack serializer (optional, resolved at runtime)
 RUN pecl install msgpack && \
   echo "extension = msgpack.so" > $(php-config --ini-dir)/msgpack.ini
 
-# Relay requires the `igbinary` extension
+# Install the `igbinary` extension for Relay's igbinary serializer (optional, resolved at runtime)
 RUN pecl install igbinary && \
   echo "extension = igbinary.so" > $(php-config --ini-dir)/igbinary.ini
 


### PR DESCRIPTION
`igbinary` and `msgpack` are now **optional** for Relay. As of the recent relay-core change, both serializers are compiled into Relay but **resolved at runtime** (bound via `dlsym` at module startup): if the extension is loaded the matching serializer is available, and if not, Relay still loads and works without it. `json` and `session` remain required.

Reword the Docker build-file comments that called `igbinary`/`msgpack` **required**. The images still install both extensions (so the serializers are available in the built images); only the now-inaccurate comments change.

Part of a cross-repo sweep updating references that still treated these extensions as hard requirements.