### PR TITLE
Replace greut/eclint-action with native editorconfig-checker

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -90,4 +90,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Check EditorConfig
-        uses: greut/eclint-action@v0
+        run: |
+          pip install editorconfig-checker==3.6.1
+          ec --format github-actions


### PR DESCRIPTION
Replaces the third-party `greut/eclint-action@v0` (effectively dormant) in the EditorConfig job with a native install of [`editorconfig-checker`](https://github.com/editorconfig-checker/editorconfig-checker), the actively-maintained checker.

```yaml
- name: Check EditorConfig
  run: |
    pip install editorconfig-checker==3.6.1
    ec --format github-actions
```

- `pip install editorconfig-checker` exposes the binary as **`ec`**.
- `--format github-actions` emits `::error file=…,line=…::…` annotations, so violations render inline in the PR diff/checks — same UX the action provided.
- Reads the repo's existing `.editorconfig` exactly as before; no excludes were configured, so none are passed.
- **Verified** `ec` runs clean (exit 0, zero findings) against a fresh checkout of the repo's tracked files.

Mirrors the same swap made in `relay.so`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)