### PR TITLE
bump version refs to v0.40.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - v0.30.0
+          - v0.40.0
           - dev
         build:
           - alpine
@@ -87,7 +87,7 @@ jobs:
     timeout-minutes: 10
 
     env:
-      RELAY_VERSION: v0.30.0
+      RELAY_VERSION: v0.40.0
 
     strategy:
       fail-fast: false

--- a/docker/al2.Dockerfile
+++ b/docker/al2.Dockerfile
@@ -29,7 +29,7 @@ RUN yum install -y \
 RUN pecl install igbinary && \
   echo "extension = igbinary.so" > $(php-config --ini-dir)/40-igbinary.ini
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Download Relay
 RUN ARCH=$(uname -m | sed 's/_/-/') \

--- a/docker/al2023.Dockerfile
+++ b/docker/al2023.Dockerfile
@@ -10,7 +10,7 @@ RUN dnf install -y \
 RUN pecl install igbinary && \
   echo "extension = igbinary.so" > $(php-config --ini-dir)/40-igbinary.ini
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Install Relay dependencies (hiredis)
 RUN dnf install -y \

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -17,7 +17,7 @@ RUN apk add \
   php81-pecl-msgpack \
   php81-pecl-igbinary
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Download Relay
 RUN PLATFORM=$(uname -m | sed 's/_/-/') \

--- a/docker/arch.Dockerfile
+++ b/docker/arch.Dockerfile
@@ -21,7 +21,7 @@ RUN curl -L https://github.com/redis/hiredis/archive/refs/tags/v1.2.0.tar.gz | t
 RUN pecl install igbinary \
   && echo "extension = igbinary.so" > $(php-config --ini-dir)/10-igbinary.ini
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Download Relay
 RUN ARCH=$(uname -m | sed 's/_/-/') \

--- a/docker/centos7/centos7.Dockerfile
+++ b/docker/centos7/centos7.Dockerfile
@@ -20,7 +20,7 @@ ENV PATH="/opt/remi/php80/root/usr/bin/:$PATH"
 ENV PHP_INI_DIR=/etc/opt/remi/php80/php.d/
 ENV PHP_EXT_DIR=/opt/remi/php80/root/usr/lib64/php/modules/
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Install Relay dependencies
 RUN yum install -y \

--- a/docker/centos8/centos8.Dockerfile
+++ b/docker/centos8/centos8.Dockerfile
@@ -17,7 +17,7 @@ ENV PATH="/opt/remi/php80/root/usr/bin/:$PATH"
 ENV PHP_INI_DIR=/etc/opt/remi/php80/php.d/
 ENV PHP_EXT_DIR=/opt/remi/php80/root/usr/lib64/php/modules/
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Install Relay dependencies
 RUN yum install -y --nogpgcheck \

--- a/docker/centos8/rocky8.Dockerfile
+++ b/docker/centos8/rocky8.Dockerfile
@@ -13,7 +13,7 @@ ENV PATH="/opt/remi/php80/root/usr/bin/:$PATH"
 ENV PHP_INI_DIR=/etc/opt/remi/php80/php.d/
 ENV PHP_EXT_DIR=/opt/remi/php80/root/usr/lib64/php/modules/
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Install Relay dependencies
 RUN yum install -y --nogpgcheck \

--- a/docker/debian/debian11.Dockerfile
+++ b/docker/debian/debian11.Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get install -y \
 RUN wget -qO- https://github.com/redis/hiredis/archive/refs/tags/v1.2.0.tar.gz | tar -xzC /tmp \
   && USE_SSL=1 make -C /tmp/hiredis-1.2.0 install
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Download Relay
 RUN PLATFORM=$(uname -m | sed 's/_/-/') \

--- a/docker/el9/el9.Dockerfile
+++ b/docker/el9/el9.Dockerfile
@@ -12,7 +12,7 @@ RUN dnf -y install php-cli
 ENV PHP_INI_DIR=/etc/php.d/
 ENV PHP_EXT_DIR=/usr/lib64/php/modules
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Install optional extensions
 RUN dnf -y install php-igbinary

--- a/docker/frankenphp.Dockerfile
+++ b/docker/frankenphp.Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
 # Install optional extensions
 RUN install-php-extensions igbinary
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Download and install Relay
 # RUN install-php-extensions "relay${RELAY:+-$RELAY}"

--- a/docker/litespeed/litespeed.Dockerfile
+++ b/docker/litespeed/litespeed.Dockerfile
@@ -19,7 +19,7 @@ RUN curl -L https://github.com/redis/hiredis/archive/refs/tags/v1.2.0.tar.gz | t
 RUN curl -L https://github.com/concurrencykit/ck/archive/refs/tags/0.7.2.tar.gz | tar -xzC /tmp \
   && cd /tmp/ck-0.7.2 && ./configure && make -j$(nproc) && make install
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Download Relay
 RUN PLATFORM=$(uname -m | sed 's/_/-/') \

--- a/docker/litespeed/openlitespeed.Dockerfile
+++ b/docker/litespeed/openlitespeed.Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install -y \
 RUN curl -L https://github.com/redis/hiredis/archive/refs/tags/v1.2.0.tar.gz | tar -xzC /tmp \
   && USE_SSL=1 make -C /tmp/hiredis-1.2.0 install
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Download Relay
 RUN PLATFORM=$(uname -m | sed 's/_/-/') \

--- a/docker/mint21.Dockerfile
+++ b/docker/mint21.Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get install -y \
 RUN curl -L https://github.com/redis/hiredis/archive/refs/tags/v1.2.0.tar.gz | tar -xzC /tmp \
   && USE_SSL=1 make -C /tmp/hiredis-1.2.0 install
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Download Relay
 RUN PHP=$(php -r 'echo substr(PHP_VERSION, 0, 3);') \

--- a/docker/sle15.Dockerfile
+++ b/docker/sle15.Dockerfile
@@ -9,7 +9,7 @@ RUN zypper --gpg-auto-import-keys update -y \
     php8-pecl \
     php8-devel
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Install Relay dependencies
 RUN zypper install -y \

--- a/docker/ubuntu/ubuntu20.Dockerfile
+++ b/docker/ubuntu/ubuntu20.Dockerfile
@@ -25,7 +25,7 @@ RUN curl -L https://github.com/redis/hiredis/archive/refs/tags/v1.2.0.tar.gz | t
 RUN curl -L https://github.com/concurrencykit/ck/archive/refs/tags/0.7.2.tar.gz | tar -xzC /tmp \
   && cd /tmp/ck-0.7.2 && ./configure && make -j$(nproc) && make install
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Download Relay
 RUN ARCH=$(uname -m | sed 's/_/-/') \

--- a/docker/ubuntu/ubuntu24-zend.Dockerfile
+++ b/docker/ubuntu/ubuntu24-zend.Dockerfile
@@ -34,7 +34,7 @@ RUN cp /usr/lib/php/8.3-zend/msgpack.so /usr/lib/php/20230831/ \
   && echo "extension=msgpack.so" > /etc/php/8.3/cli/conf.d/30-msgpack.ini \
   && echo "extension=igbinary.so" > /etc/php/8.3/cli/conf.d/30-igbinary.ini
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Download Relay
 RUN ARCH=$(uname -m | sed 's/_/-/') \

--- a/docker/ubuntu/ubuntu24.Dockerfile
+++ b/docker/ubuntu/ubuntu24.Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get install -y \
   php-msgpack \
   php-igbinary
 
-ARG RELAY=v0.30.0
+ARG RELAY=v0.40.0
 
 # Download Relay
 RUN ARCH=$(uname -m | sed 's/_/-/') \


### PR DESCRIPTION
Bumps the pinned Relay version from `v0.30.0` to `v0.40.0`.

- `ARG RELAY=v0.40.0` in the 17 Dockerfiles that pin a release
- `.github/workflows/docker.yml`: artifact build matrix version and `RELAY_VERSION` (used for the pie-latest build arg and the version verification step)

Untouched on purpose:
- `docker/pie/pie-pinned.Dockerfile` — deliberately pins an old version (`0.20.0`) to exercise PIE version pinning; the workflow skips version verification for it
- `docker/README.md` — `RELAY=v0.9.1` is an illustrative example, not a pin
- `benchmarks/release-v0.30.0-*` — historical charts for that release

🤖 Generated with [Claude Code](https://claude.com/claude-code)